### PR TITLE
`sslmode` fix

### DIFF
--- a/charts/mautrix-bluesky/Chart.yaml
+++ b/charts/mautrix-bluesky/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/bluesky/
 sources:
   - https://github.com/mautrix/bluesky
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2510.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_bluesky
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-bluesky/values.external.example.yaml
+++ b/charts/mautrix-bluesky/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_bluesky
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-bluesky/values.schema.json
+++ b/charts/mautrix-bluesky/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-bluesky/values.yaml
+++ b/charts/mautrix-bluesky/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_bluesky_password
     database: mautrix_bluesky
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-gmessages/Chart.yaml
+++ b/charts/mautrix-gmessages/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/gmessages/
 sources:
   - https://github.com/mautrix/gmessages
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_gmessages
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-gmessages/values.external.example.yaml
+++ b/charts/mautrix-gmessages/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_gmessages
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-gmessages/values.schema.json
+++ b/charts/mautrix-gmessages/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-gmessages/values.yaml
+++ b/charts/mautrix-gmessages/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_gmessages_password
     database: mautrix_gmessages
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-googlechat/Chart.yaml
+++ b/charts/mautrix-googlechat/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/googlechat/
 sources:
   - https://github.com/mautrix/googlechat
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: "v0.5.2"

--- a/charts/mautrix-googlechat/README.md
+++ b/charts/mautrix-googlechat/README.md
@@ -138,7 +138,7 @@ database:
     password:
       value: replace_me
     database: mautrix_googlechat
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-googlechat/values.external.example.yaml
+++ b/charts/mautrix-googlechat/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_googlechat
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-googlechat/values.schema.json
+++ b/charts/mautrix-googlechat/values.schema.json
@@ -263,10 +263,7 @@
               "type": "string",
               "default": "disable",
               "enum": [
-                "",
                 "disable",
-                "allow",
-                "prefer",
                 "require",
                 "verify-ca",
                 "verify-full"

--- a/charts/mautrix-googlechat/values.yaml
+++ b/charts/mautrix-googlechat/values.yaml
@@ -94,7 +94,7 @@ database:
     password:
       value: mautrix_googlechat_password
     database: mautrix_googlechat
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-gvoice/Chart.yaml
+++ b/charts/mautrix-gvoice/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/gvoice/
 sources:
   - https://github.com/mautrix/gvoice
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_gvoice
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-gvoice/values.external.example.yaml
+++ b/charts/mautrix-gvoice/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_gvoice
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-gvoice/values.schema.json
+++ b/charts/mautrix-gvoice/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-gvoice/values.yaml
+++ b/charts/mautrix-gvoice/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_gvoice_password
     database: mautrix_gvoice
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-linkedin/Chart.yaml
+++ b/charts/mautrix-linkedin/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/linkedin/
 sources:
   - https://github.com/mautrix/linkedin
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_linkedin
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-linkedin/values.external.example.yaml
+++ b/charts/mautrix-linkedin/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_linkedin
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-linkedin/values.schema.json
+++ b/charts/mautrix-linkedin/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-linkedin/values.yaml
+++ b/charts/mautrix-linkedin/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_linkedin_password
     database: mautrix_linkedin
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-meta/Chart.yaml
+++ b/charts/mautrix-meta/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/meta/
 sources:
   - https://github.com/mautrix/meta
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_meta
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-meta/values.external.example.yaml
+++ b/charts/mautrix-meta/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_meta
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-meta/values.schema.json
+++ b/charts/mautrix-meta/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-meta/values.yaml
+++ b/charts/mautrix-meta/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_meta_password
     database: mautrix_meta
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-signal/Chart.yaml
+++ b/charts/mautrix-signal/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/signal/
 sources:
   - https://github.com/mautrix/signal
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2602.2"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_signal
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-signal/values.external.example.yaml
+++ b/charts/mautrix-signal/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_signal
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-signal/values.schema.json
+++ b/charts/mautrix-signal/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-signal/values.yaml
+++ b/charts/mautrix-signal/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_signal_password
     database: mautrix_signal
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-slack/Chart.yaml
+++ b/charts/mautrix-slack/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/slack/
 sources:
   - https://github.com/mautrix/slack
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_slack
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-slack/values.external.example.yaml
+++ b/charts/mautrix-slack/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_slack
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-slack/values.schema.json
+++ b/charts/mautrix-slack/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-slack/values.yaml
+++ b/charts/mautrix-slack/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_slack_password
     database: mautrix_slack
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-telegram/Chart.yaml
+++ b/charts/mautrix-telegram/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/telegram/
 sources:
   - https://github.com/mautrix/telegram
 type: application
-version: 0.9.2
+version: 0.9.3
 appVersion: "v0.15.3"

--- a/charts/mautrix-telegram/README.md
+++ b/charts/mautrix-telegram/README.md
@@ -146,7 +146,7 @@ database:
     password:
       value: replace_me
     database: mautrix_telegram
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-telegram/values.external.example.yaml
+++ b/charts/mautrix-telegram/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_telegram
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-telegram/values.schema.json
+++ b/charts/mautrix-telegram/values.schema.json
@@ -286,10 +286,7 @@
               "type": "string",
               "default": "disable",
               "enum": [
-                "",
                 "disable",
-                "allow",
-                "prefer",
                 "require",
                 "verify-ca",
                 "verify-full"

--- a/charts/mautrix-telegram/values.yaml
+++ b/charts/mautrix-telegram/values.yaml
@@ -100,7 +100,7 @@ database:
     password:
       value: mautrix_telegram_password
     database: mautrix_telegram
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-twitter/Chart.yaml
+++ b/charts/mautrix-twitter/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/twitter/
 sources:
   - https://github.com/mautrix/twitter
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_twitter
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-twitter/values.external.example.yaml
+++ b/charts/mautrix-twitter/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_twitter
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-twitter/values.schema.json
+++ b/charts/mautrix-twitter/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-twitter/values.yaml
+++ b/charts/mautrix-twitter/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_twitter_password
     database: mautrix_twitter
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-whatsapp/Chart.yaml
+++ b/charts/mautrix-whatsapp/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/whatsapp/
 sources:
   - https://github.com/mautrix/whatsapp
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_whatsapp
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-whatsapp/values.external.example.yaml
+++ b/charts/mautrix-whatsapp/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_whatsapp
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-whatsapp/values.schema.json
+++ b/charts/mautrix-whatsapp/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-whatsapp/values.yaml
+++ b/charts/mautrix-whatsapp/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_whatsapp_password
     database: mautrix_whatsapp
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true

--- a/charts/mautrix-zulip/Chart.yaml
+++ b/charts/mautrix-zulip/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/zulip/
 sources:
   - https://github.com/mautrix/zulip
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -223,7 +223,7 @@ database:
     password:
       value: replace_me
     database: mautrix_zulip
-    sslMode: prefer
+    sslMode: require
 ```
 
 See: `values.external.example.yaml`

--- a/charts/mautrix-zulip/values.external.example.yaml
+++ b/charts/mautrix-zulip/values.external.example.yaml
@@ -16,7 +16,7 @@ database:
     password:
       value: replace_me
     database: mautrix_zulip
-    sslMode: prefer
+    sslMode: require
 
 homeserver:
   domain: matrix.example.com

--- a/charts/mautrix-zulip/values.schema.json
+++ b/charts/mautrix-zulip/values.schema.json
@@ -412,7 +412,13 @@
             },
             "sslMode": {
               "type": "string",
-              "default": "prefer"
+              "default": "disable",
+              "enum": [
+                "disable",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
             }
           }
         }

--- a/charts/mautrix-zulip/values.yaml
+++ b/charts/mautrix-zulip/values.yaml
@@ -129,7 +129,7 @@ database:
     password:
       value: mautrix_zulip_password
     database: mautrix_zulip
-    sslMode: prefer
+    sslMode: disable
 
 postgres:
   enabled: true


### PR DESCRIPTION
The `mautrix-*` bridges do not support the same `sslmode` as `matrix-appservice-irc` which was the initial basis for those charts. I'd never tested as I've always been deploying to my own managed DBs in a separate postgres.

This should resolve #13 by removing it from the README / Example `values/yaml` as well as removing it as the default mode when unspecified.