### PR TITLE
Version 1.0.0 Releases for all Charts

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 This guide is the quickest way to install one of the charts in this repository for a Matrix setup.
 
-Generally speaking, I'd advise to start small.
+Generally speaking, I'd advise to start with minimal configuration.
 
 For a first deployment, only change what is required to get started, then once working you can try component-specific config.
 
@@ -89,7 +89,7 @@ kubectl get pods -n "${CHART}" -w
 
 Once the pod is ready, the chart itself is installed.
 
-If any pod seems to be having issue, use the following to understand why:
+If any pod has an issue, use the following to understand why:
 
 ```bash
 # Make sure to replace `POD_NAME` with the name of the erroring pod!
@@ -97,8 +97,8 @@ kubectl logs POD_NAME -n "${CHART}"
 kubectl describe pod POD_NAME -n "${CHART}"
 ```
 
-> ![TIP]
-> Installing a bridge? If you see `as_token` issues, this is expected, you still need to link up your Synapse per the following steps!
+> [!TIP]
+> Installing a bridge? If you see `as_token` issues, this can be expected at this stage as you still need to link up those credentials with your Synapse per the following steps!
 
 ## 6. Start Using It
 
@@ -116,10 +116,10 @@ After the Helm install:
 
     ```yaml
     synapse:
-    appservices:
+      appservices:
         # Replace `mautrix-whatsapp` / `whatsapp` with the chart name of your choice
         - configMap: mautrix-whatsapp-registration
-        configMapKey: appservice-registration-whatsapp.yaml
+          configMapKey: appservice-registration-whatsapp.yaml
     ```
 
 2. Redeploy Synapse so it starts using that registration.
@@ -155,6 +155,6 @@ This guide is intentionally simple. After your first install command, use the sp
 
 You can find chart READMEs under [`charts/`](./charts/).
 
-All charts are designed to be as minimal as possible as such they defer most all configuration to the underlying components native config.
+All charts are designed to be as minimal as possible, so they defer most configuration to the underlying component's native config.
 
-Check out each components associated repo / linked config examples to learn more.
+Check out each component's associated repo / linked config examples to learn more.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,160 @@
+# Installation Guide
+
+This guide is the quickest way to install one of the charts in this repository for a Matrix setup.
+
+Generally speaking, I'd advise to start small.
+
+For a first deployment, only change what is required to get started, then once working you can try component-specific config.
+
+## Before You Start
+
+You should have:
+
+- A working Kubernetes cluster
+- Helm 3 installed on your machine
+- A Matrix homeserver that your cluster can reach
+- The name of the chart you want to install
+
+Installable chart names are:
+
+- `ntfy`
+- `matrix-appservice-irc`
+- `mautrix-bluesky`
+- `mautrix-gmessages`
+- `mautrix-googlechat`
+- `mautrix-gvoice`
+- `mautrix-linkedin`
+- `mautrix-meta`
+- `mautrix-signal`
+- `mautrix-slack`
+- `mautrix-telegram`
+- `mautrix-twitter`
+- `mautrix-whatsapp`
+- `mautrix-zulip`
+
+## 1. Choose Your Chart
+
+Pick the chart that matches the service or bridge you want to run.
+
+Example:
+
+```bash
+export CHART=mautrix-whatsapp
+```
+
+If you are installing `ntfy` instead, set:
+
+```bash
+export CHART=ntfy
+```
+
+## 2. Download the Matrix Example Values File
+
+Every installable chart in this repository includes a Matrix-focused example values file. Download that file first and use it as your starting point:
+
+```bash
+curl -L "https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/main/charts/${CHART}/values.matrix.example.yaml" -o "${CHART}-values.yaml"
+```
+
+This gives you a local file such as `mautrix-whatsapp-values.yaml`.
+
+## 3. Configure Your Values File
+
+Open the file you just downloaded and replace the obvious placeholder values with your real details. Just follow the guidance of the comments within the file.
+
+For a first install, leave everything else alone unless you already know you need to change it.
+
+The `values.matrix.example.yaml` files are intended to be the easiest starting point for Matrix and ESS Community deployments.
+
+## 4. Install the Chart
+
+Install with the published OCI chart using the chart name as both the Helm release name and the namespace:
+
+```bash
+helm upgrade --install "${CHART}" "oci://ghcr.io/cyclikal94/matrix-helm-charts/${CHART}" \
+  --namespace "${CHART}" \
+  --create-namespace \
+  --values "./${CHART}-values.yaml"
+```
+
+This uses the standard defaults from the chart and creates the namespace for you if it does not already exist.
+
+## 5. Wait for the Deployment to Start
+
+Watch the new namespace until the pod is running:
+
+```bash
+kubectl get pods -n "${CHART}" -w
+```
+
+Once the pod is ready, the chart itself is installed.
+
+If any pod seems to be having issue, use the following to understand why:
+
+```bash
+# Make sure to replace `POD_NAME` with the name of the erroring pod!
+kubectl logs POD_NAME -n "${CHART}"
+kubectl describe pod POD_NAME -n "${CHART}"
+```
+
+> ![TIP]
+> Installing a bridge? If you see `as_token` issues, this is expected, you still need to link up your Synapse per the following steps!
+
+## 6. Start Using It
+
+What happens next depends on what you installed.
+
+### If You Installed a Bridge
+
+This applies to `matrix-appservice-irc` and all `mautrix-*` charts.
+
+After the Helm install:
+
+1. Add the generated appservice registration ConfigMap to your Synapse deployment.
+
+    To do this with ESS Community, simply create a new `values.yaml` called `appservices.yaml` like so:
+
+    ```yaml
+    synapse:
+    appservices:
+        # Replace `mautrix-whatsapp` / `whatsapp` with the chart name of your choice
+        - configMap: mautrix-whatsapp-registration
+        configMapKey: appservice-registration-whatsapp.yaml
+    ```
+
+2. Redeploy Synapse so it starts using that registration.
+
+    To do this with ESS Community, simply redeploy using the same `helm upgrade` command, but make sure to include this `appservices.yaml` file as an extra `--values`:
+
+    ```bash
+    helm upgrade --install --namespace "ess" ess \
+        oci://ghcr.io/element-hq/ess-helm/matrix-stack \
+        -f ~/ess-config-values/hostnames.yaml \
+        -f ~/ess-config-values/tls.yaml \
+        -f ~/ess-config-values/appservices.yaml \
+        --wait
+    ```
+
+3. Start a DM with the bridge bot in Matrix.
+
+    By default, usually named after the bridge itself, i.e. `whatsappbot`, so if your homeserver was `example.com` with users like `@user:example.com`, you would start a DM with `@whatsappbot:example.com`.
+
+4. Follow the bot prompts to sign in or connect your account.
+
+### If You Installed `ntfy`
+
+After the Helm install:
+
+1. Open the hostname you configured for `ntfy`.
+2. Confirm the service is reachable in your browser or client.
+3. Point your Matrix client or UnifiedPush-compatible app at that `ntfy` server.
+
+## 7. Making it your own!
+
+This guide is intentionally simple. After your first install command, use the specific chart README for how to further configure.
+
+You can find chart READMEs under [`charts/`](./charts/).
+
+All charts are designed to be as minimal as possible as such they defer most all configuration to the underlying components native config.
+
+Check out each components associated repo / linked config examples to learn more.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ helm upgrade --install <release-name> matrix-helm-charts/<chart-name> --namespac
 
 ## Components
 
+![TIP]
+Click on the desired helm charts' badge to be taken to its README for detailed deployment information.
+
+
 Components are organised into categories copying the [matrix.org Ecosystem](https://matrix.org/ecosystem/) section. As such components will be either `Clients`, `Bridges`, `Servers`, or `Integrations` - where components aren't present on [matrix.org](https://matrix.org/ecosystem/) I'll do my best to put them in an appropriate category. The remaining catefories of `SDKs`, `Distribution` and `Hosting` are unlikely to be applicable here.
 
 Given this is new, I'm actively looking for useful new charts to make, I'm prioritising projects listed on [matrix.org Ecosystem](https://matrix.org/ecosystem/) likely filtering on a "Maturity" of `Stable` / `Beta` - if you have suggestions, please do raise an issue!
-
-> [!NOTE]
-> Please note that I am actively testing each helm chart and plan to make `1.0.0` releases only after each have been tested / considered ready. For now, `ntfy`, `matrix-appservice-irc` and the two Python-based Mautrix bridges `mautrix-telegram` / `mautrix-googlechat` have been confirmed tested and working, hence `0.9.X` versions, but are due a `1.0.0` after further testing of different configurations / deployments.
 
 ### Integrations
 
@@ -112,9 +113,6 @@ A Matrix-Telegram hybrid puppeting/relaybot bridge. Note this is a `mautrix` pyt
 #### Go Bridges
 
 Double puppetting is enabled by default, and as such, any charts sharing the same `mautrix-go-base` chart version will use the same double puppet App Service registration automatically.
-
-> [!NOTE]
-> The `mautrix-go-base` components are in-progress, though `mautrix-whatsapp` and `mautrix-linkedin` have been deployed and appear to be working (including Double Puppetting) but YMMV so for now they are `1.0.X` until I can fully test.
 
 <table><tr><td>
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Generally speaking, installation / usage follows these steps:
 2. Point your Synapse deployment at the generated App Service Registration file, i.e. if using ESS Community, just redeploy with the sample `values.yaml` per the chart `README.md`.
 3. Start a DM with the bot `@componentnamebot:example.com`, i.e. `@whatsappbot:example.com`, login etc.
 
+> [!TIP]
+> You should start with the [INSTALLATION](INSTALLATION.md) guide!.
+
 ### OCI Registry (Preferred)
 
 All charts are published as OCI artifacts on GHCR:

--- a/charts/matrix-appservice-irc/Chart.yaml
+++ b/charts/matrix-appservice-irc/Chart.yaml
@@ -5,5 +5,5 @@ home: https://matrix-org.github.io/matrix-appservice-irc/latest/
 sources:
   - https://github.com/matrix-org/matrix-appservice-irc
 type: application
-version: 0.9.14
+version: 1.0.0
 appVersion: "release-4.0.0"

--- a/charts/matrix-appservice-irc/README.md
+++ b/charts/matrix-appservice-irc/README.md
@@ -2,6 +2,9 @@
 
 This is an IRC bridge for Matrix. See [matrix-org/matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys matrix-appservice-irc with a ConfigMap, Service, Deployment(s), optional bundled Redis/Postgres StatefulSets, and media proxy Ingress.

--- a/charts/matrix-appservice-irc/README.md
+++ b/charts/matrix-appservice-irc/README.md
@@ -1,4 +1,4 @@
-# matrix-appservice-irc [![matrix-appservice-irc chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.matrix-appservice-irc%5B0%5D.version&label=matrix-appservice-irc&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/matrix-appservice-irc)
+# matrix-appservice-irc [![matrix-appservice-irc chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.matrix-appservice-irc%5B0%5D.version&label=matrix-appservice-irc&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/matrix-appservice-irc)
 
 This is an IRC bridge for Matrix. See [matrix-org/matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) for details.
 

--- a/charts/mautrix-bluesky/Chart.lock
+++ b/charts/mautrix-bluesky/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.164769Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:05.7181954Z"

--- a/charts/mautrix-bluesky/Chart.yaml
+++ b/charts/mautrix-bluesky/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/bluesky/
 sources:
   - https://github.com/mautrix/bluesky
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2510.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Bluesky puppeting bridge. See [mautrix/bluesky](https://github.com/mautrix/bluesky) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-bluesky` with:

--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -1,4 +1,4 @@
-# mautrix-bluesky [![mautrix-bluesky chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-bluesky%5B0%5D.version&label=mautrix-bluesky&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-bluesky)
+# mautrix-bluesky [![mautrix-bluesky chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-bluesky%5B0%5D.version&label=mautrix-bluesky&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-bluesky)
 
 A Matrix-Bluesky puppeting bridge. See [mautrix/bluesky](https://github.com/mautrix/bluesky) for details.
 

--- a/charts/mautrix-gmessages/Chart.lock
+++ b/charts/mautrix-gmessages/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.197167Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:05.9337513Z"

--- a/charts/mautrix-gmessages/Chart.yaml
+++ b/charts/mautrix-gmessages/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/gmessages/
 sources:
   - https://github.com/mautrix/gmessages
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Google-Messages puppeting bridge. See [mautrix/gmessages](https://github.com/mautrix/gmessages) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-gmessages` with:

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -1,4 +1,4 @@
-# mautrix-gmessages [![mautrix-gmessages chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-gmessages%5B0%5D.version&label=mautrix-gmessages&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-gmessages)
+# mautrix-gmessages [![mautrix-gmessages chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-gmessages%5B0%5D.version&label=mautrix-gmessages&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-gmessages)
 
 A Matrix-Google-Messages puppeting bridge. See [mautrix/gmessages](https://github.com/mautrix/gmessages) for details.
 

--- a/charts/mautrix-go-base/Chart.yaml
+++ b/charts/mautrix-go-base/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/mautrix
   - https://github.com/cyclikal94/matrix-helm-charts
 type: library
-version: 0.1.4
+version: 1.0.0
 appVersion: "0.0.0"

--- a/charts/mautrix-go-base/README.md
+++ b/charts/mautrix-go-base/README.md
@@ -6,10 +6,10 @@ Shared Helm library chart for mautrix Go bridge wrappers.
 
 This chart centralizes Kubernetes resource templates and shared helper logic so bridge-specific charts only define:
 
-- bridge-specific managed config and reserved path declarations
-- bridge command and startup args
-- registration file key and regex defaults
-- chart metadata, schema, and examples
+- Bridge-specific managed config and reserved path declarations
+- Bridge command and startup args
+- Registration file key and regex defaults
+- Chart metadata, schema, and examples
 
 ## Wrapper Contract
 
@@ -43,29 +43,29 @@ A wrapper chart that depends on this library must define these helpers:
 
 Templates in this library follow mautrix Kubernetes guidance:
 
-- direct bridge command (no startup script)
+- Direct bridge command (no startup script)
 - `--no-update` support via wrapper args
-- read-only config mount at `/data`
-- singleton bridge StatefulSet (`replicas: 1`)
+- Read-only config mount at `/data`
+- Singleton bridge StatefulSet (`replicas: 1`)
 - `publishNotReadyAddresses: true`
-- optional probes only (disabled by default)
+- Optional probes only (disabled by default)
 
 ## New Go Bridge Checklist
 
-Use `mautrix-whatsapp` as the scaffold:
+If you want to make a new Go Bridge chart, simply:
 
 1. Copy `charts/mautrix-whatsapp` to a new chart name.
 2. Update `Chart.yaml` metadata and image defaults.
 3. Update wrapper helpers in `templates/_helpers.tpl`:
-- `registrationFileKey`
-- `defaultRegistrationUserRegex`
-- `managedConfig`
-- `reservedBasePaths`
-- `reservedNetworkPaths`
-- `doublePuppetRegistrationFileKey`
-- `doublePuppetUserRegex`
-- `mergedConfig` include call to `mautrix-go-base.bridgev2MergedConfig`
-- any bridge-specific config defaults
+    - `registrationFileKey`
+    - `defaultRegistrationUserRegex`
+    - `managedConfig`
+    - `reservedBasePaths`
+    - `reservedNetworkPaths`
+    - `doublePuppetRegistrationFileKey`
+    - `doublePuppetUserRegex`
+    - `mergedConfig` include call to `mautrix-go-base.bridgev2MergedConfig`
+    - any bridge-specific config defaults
 4. Keep Kubernetes runtime shape unchanged unless bridge behavior requires it.
 5. Update `values.yaml`, `values.schema.json`, and examples.
 6. Update chart README and root docs tables.

--- a/charts/mautrix-go-base/README.md
+++ b/charts/mautrix-go-base/README.md
@@ -2,6 +2,9 @@
 
 Shared Helm library chart for mautrix Go bridge wrappers.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Purpose
 
 This chart centralizes Kubernetes resource templates and shared helper logic so bridge-specific charts only define:

--- a/charts/mautrix-go-base/README.md
+++ b/charts/mautrix-go-base/README.md
@@ -1,4 +1,4 @@
-# mautrix-go-base [![mautrix-go-base chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-go-base%5B0%5D.version&label=mautrix-go-base&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-go-base)
+# mautrix-go-base [![mautrix-go-base chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-go-base%5B0%5D.version&label=mautrix-go-base&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-go-base)
 
 Shared Helm library chart for mautrix Go bridge wrappers.
 

--- a/charts/mautrix-googlechat/Chart.yaml
+++ b/charts/mautrix-googlechat/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/googlechat/
 sources:
   - https://github.com/mautrix/googlechat
 type: application
-version: 0.9.2
+version: 1.0.0
 appVersion: "v0.5.2"

--- a/charts/mautrix-googlechat/README.md
+++ b/charts/mautrix-googlechat/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Google Chat puppeting bridge. See [mautrix/googlechat](https://github.com/mautrix/googlechat) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-googlechat` with:

--- a/charts/mautrix-googlechat/README.md
+++ b/charts/mautrix-googlechat/README.md
@@ -1,4 +1,4 @@
-# mautrix-googlechat [![mautrix-googlechat chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-googlechat%5B0%5D.version&label=mautrix-googlechat&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-googlechat)
+# mautrix-googlechat [![mautrix-googlechat chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-googlechat%5B0%5D.version&label=mautrix-googlechat&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-googlechat)
 
 A Matrix-Google Chat puppeting bridge. See [mautrix/googlechat](https://github.com/mautrix/googlechat) for details.
 

--- a/charts/mautrix-gvoice/Chart.lock
+++ b/charts/mautrix-gvoice/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.261624Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:06.1388541Z"

--- a/charts/mautrix-gvoice/Chart.yaml
+++ b/charts/mautrix-gvoice/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/gvoice/
 sources:
   - https://github.com/mautrix/gvoice
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Google-Voice puppeting bridge. See [mautrix/gvoice](https://github.com/mautrix/gvoice) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-gvoice` with:

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -1,4 +1,4 @@
-# mautrix-gvoice [![mautrix-gvoice chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-gvoice%5B0%5D.version&label=mautrix-gvoice&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-gvoice)
+# mautrix-gvoice [![mautrix-gvoice chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-gvoice%5B0%5D.version&label=mautrix-gvoice&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-gvoice)
 
 A Matrix-Google-Voice puppeting bridge. See [mautrix/gvoice](https://github.com/mautrix/gvoice) for details.
 

--- a/charts/mautrix-linkedin/Chart.lock
+++ b/charts/mautrix-linkedin/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.294222Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:06.3410611Z"

--- a/charts/mautrix-linkedin/Chart.yaml
+++ b/charts/mautrix-linkedin/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/linkedin/
 sources:
   - https://github.com/mautrix/linkedin
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-LinkedIn puppeting bridge. See [mautrix/linkedin](https://github.com/mautrix/linkedin) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-linkedin` with:

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -1,4 +1,4 @@
-# mautrix-linkedin [![mautrix-linkedin chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-linkedin%5B0%5D.version&label=mautrix-linkedin&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-linkedin)
+# mautrix-linkedin [![mautrix-linkedin chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-linkedin%5B0%5D.version&label=mautrix-linkedin&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-linkedin)
 
 A Matrix-LinkedIn puppeting bridge. See [mautrix/linkedin](https://github.com/mautrix/linkedin) for details.
 

--- a/charts/mautrix-meta/Chart.lock
+++ b/charts/mautrix-meta/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-04T08:34:31.426665Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:06.5461775Z"

--- a/charts/mautrix-meta/Chart.yaml
+++ b/charts/mautrix-meta/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/meta/
 sources:
   - https://github.com/mautrix/meta
 type: application
-version: 0.1.1
+version: 1.0.0
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Meta puppeting bridge. See [mautrix/meta](https://github.com/mautrix/meta) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-meta` with:

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -1,4 +1,4 @@
-# mautrix-meta [![mautrix-meta chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-meta%5B0%5D.version&label=mautrix-meta&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-meta)
+# mautrix-meta [![mautrix-meta chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-meta%5B0%5D.version&label=mautrix-meta&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-meta)
 
 A Matrix-Meta puppeting bridge. See [mautrix/meta](https://github.com/mautrix/meta) for details.
 

--- a/charts/mautrix-signal/Chart.lock
+++ b/charts/mautrix-signal/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.326051Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:06.7528697Z"

--- a/charts/mautrix-signal/Chart.yaml
+++ b/charts/mautrix-signal/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/signal/
 sources:
   - https://github.com/mautrix/signal
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2602.2"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Signal puppeting bridge. See [mautrix/signal](https://github.com/mautrix/signal) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-signal` with:

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -1,4 +1,4 @@
-# mautrix-signal [![mautrix-signal chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-signal%5B0%5D.version&label=mautrix-signal&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-signal)
+# mautrix-signal [![mautrix-signal chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-signal%5B0%5D.version&label=mautrix-signal&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-signal)
 
 A Matrix-Signal puppeting bridge. See [mautrix/signal](https://github.com/mautrix/signal) for details.
 

--- a/charts/mautrix-slack/Chart.lock
+++ b/charts/mautrix-slack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.357549Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:06.9708255Z"

--- a/charts/mautrix-slack/Chart.yaml
+++ b/charts/mautrix-slack/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/slack/
 sources:
   - https://github.com/mautrix/slack
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Slack puppeting bridge. See [mautrix/slack](https://github.com/mautrix/slack) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-slack` with:

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -1,4 +1,4 @@
-# mautrix-slack [![mautrix-slack chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-slack%5B0%5D.version&label=mautrix-slack&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-slack)
+# mautrix-slack [![mautrix-slack chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-slack%5B0%5D.version&label=mautrix-slack&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-slack)
 
 A Matrix-Slack puppeting bridge. See [mautrix/slack](https://github.com/mautrix/slack) for details.
 

--- a/charts/mautrix-telegram/Chart.yaml
+++ b/charts/mautrix-telegram/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/telegram/
 sources:
   - https://github.com/mautrix/telegram
 type: application
-version: 0.9.3
+version: 1.0.0
 appVersion: "v0.15.3"

--- a/charts/mautrix-telegram/README.md
+++ b/charts/mautrix-telegram/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Telegram hybrid puppeting/relaybot bridge. See [mautrix/telegram](https://github.com/mautrix/telegram) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-telegram` with:

--- a/charts/mautrix-telegram/README.md
+++ b/charts/mautrix-telegram/README.md
@@ -1,4 +1,4 @@
-# mautrix-telegram [![mautrix-telegram chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-telegram%5B0%5D.version&label=mautrix-telegram&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-telegram)
+# mautrix-telegram [![mautrix-telegram chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-telegram%5B0%5D.version&label=mautrix-telegram&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-telegram)
 
 A Matrix-Telegram hybrid puppeting/relaybot bridge. See [mautrix/telegram](https://github.com/mautrix/telegram) for details.
 

--- a/charts/mautrix-twitter/Chart.lock
+++ b/charts/mautrix-twitter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.393883Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:07.1794493Z"

--- a/charts/mautrix-twitter/Chart.yaml
+++ b/charts/mautrix-twitter/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/twitter/
 sources:
   - https://github.com/mautrix/twitter
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Twitter puppeting bridge. See [mautrix/twitter](https://github.com/mautrix/twitter) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-twitter` with:

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -1,4 +1,4 @@
-# mautrix-twitter [![mautrix-twitter chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-twitter%5B0%5D.version&label=mautrix-twitter&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-twitter)
+# mautrix-twitter [![mautrix-twitter chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-twitter%5B0%5D.version&label=mautrix-twitter&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-twitter)
 
 A Matrix-Twitter puppeting bridge. See [mautrix/twitter](https://github.com/mautrix/twitter) for details.
 

--- a/charts/mautrix-whatsapp/Chart.lock
+++ b/charts/mautrix-whatsapp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.426756Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:07.3854006Z"

--- a/charts/mautrix-whatsapp/Chart.yaml
+++ b/charts/mautrix-whatsapp/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/whatsapp/
 sources:
   - https://github.com/mautrix/whatsapp
 type: application
-version: 0.1.7
+version: 1.0.0
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-WhatsApp puppeting bridge. See [mautrix/whatsapp](https://github.com/mautrix/whatsapp) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-whatsapp` with:

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -1,4 +1,4 @@
-# mautrix-whatsapp [![mautrix-whatsapp chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-whatsapp%5B0%5D.version&label=mautrix-whatsapp&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-whatsapp)
+# mautrix-whatsapp [![mautrix-whatsapp chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-whatsapp%5B0%5D.version&label=mautrix-whatsapp&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-whatsapp)
 
 A Matrix-WhatsApp puppeting bridge. See [mautrix/whatsapp](https://github.com/mautrix/whatsapp) for details.
 

--- a/charts/mautrix-zulip/Chart.lock
+++ b/charts/mautrix-zulip/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 0.1.4
-digest: sha256:70a213228afd6d74ee5801ced22db7e1b3db56b09721fe7fa61d6e2fe59ededc
-generated: "2026-03-03T15:55:48.458421Z"
+  version: 1.0.0
+digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
+generated: "2026-03-13T10:06:07.5915573Z"

--- a/charts/mautrix-zulip/Chart.yaml
+++ b/charts/mautrix-zulip/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/zulip/
 sources:
   - https://github.com/mautrix/zulip
 type: application
-version: 0.1.2
+version: 1.0.0
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base
-    version: 0.1.4
+    version: 1.0.0
     repository: file://../mautrix-go-base

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -2,6 +2,9 @@
 
 A Matrix-Zulip puppeting bridge. See [mautrix/zulip](https://github.com/mautrix/zulip) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys `mautrix-zulip` with:

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -1,4 +1,4 @@
-# mautrix-zulip [![mautrix-zulip chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-zulip%5B0%5D.version&label=mautrix-zulip&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-zulip)
+# mautrix-zulip [![mautrix-zulip chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.mautrix-zulip%5B0%5D.version&label=mautrix-zulip&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/mautrix-zulip)
 
 A Matrix-Zulip puppeting bridge. See [mautrix/zulip](https://github.com/mautrix/zulip) for details.
 

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -6,5 +6,5 @@ home: https://ntfy.sh
 sources:
   - https://github.com/binwiederhier/ntfy
 type: application
-version: 0.9.7
+version: 1.0.0
 appVersion: "v2.17.0"

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -2,6 +2,9 @@
 
 ntfy (pronounced "notify") is a simple HTTP-based pub-sub notification service. See [binwiederhier/ntfy](https://github.com/binwiederhier/ntfy) for details.
 
+> [!TIP]
+> Not interested in the nitty-gritty technical details? Start with the [INSTALLATION](../../INSTALLATION.md) guide!.
+
 ## Overview
 
 This chart deploys ntfy with a ConfigMap, Service, StatefulSet, and Ingress.

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -1,4 +1,4 @@
-# ntfy [![ntfy chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.ntfy%5B0%5D.version&label=ntfy&logo=helm)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/ntfy)
+# ntfy [![ntfy chart version](https://img.shields.io/badge/dynamic/yaml?url=https://raw.githubusercontent.com/cyclikal94/matrix-helm-charts/gh-pages/index.yaml&query=%24.entries.ntfy%5B0%5D.version&label=ntfy&logo=helm&style=for-the-badge)](https://github.com/cyclikal94/matrix-helm-charts/tree/main/charts/ntfy)
 
 ntfy (pronounced "notify") is a simple HTTP-based pub-sub notification service. See [binwiederhier/ntfy](https://github.com/binwiederhier/ntfy) for details.
 


### PR DESCRIPTION
- Bump of all charts to version `1.0.0`
- Lots of README fixes / general clean-up
- Introduction of INSTALLATION.md for a clean simple install guide to get people setup quick