### PR TITLE
Fix pages table markdown

### DIFF
--- a/.github/scripts/render-pages-index.sh
+++ b/.github/scripts/render-pages-index.sh
@@ -46,4 +46,4 @@ fi
       print
     }
   ' "${readme_path}"
-} > "${output_path}"
+} | perl -pe 's{<t([dh])\b(?![^>]*\bmarkdown=)([^>]*)>}{<t$1 markdown="1"$2>}g' > "${output_path}"

--- a/.github/scripts/render-pages-index.sh
+++ b/.github/scripts/render-pages-index.sh
@@ -25,8 +25,22 @@ fi
     BEGIN {
       skipped_h1 = 0
       dropped_overview = 0
+      in_admonition = 0
     }
     {
+      if (in_admonition) {
+        if ($0 ~ /^>/) {
+          line = $0
+          sub(/^> ?/, "", line)
+          print line
+          next
+        }
+
+        print "</div>"
+        print ""
+        in_admonition = 0
+      }
+
       if (!skipped_h1 && $0 ~ /^# /) {
         skipped_h1 = 1
         next
@@ -43,7 +57,25 @@ fi
         dropped_overview = 1
       }
 
+      if ($0 ~ /^> \[![A-Z]+\][[:space:]]*$/) {
+        label = $0
+        sub(/^> \[!/, "", label)
+        sub(/\][[:space:]]*$/, "", label)
+        class_name = tolower(label)
+        label = toupper(substr(label, 1, 1)) tolower(substr(label, 2))
+        print "<div class=\"pages-callout pages-callout-" class_name "\" markdown=\"1\">"
+        print "<p class=\"pages-callout-title\">" label "</p>"
+        print ""
+        in_admonition = 1
+        next
+      }
+
       print
+    }
+    END {
+      if (in_admonition) {
+        print "</div>"
+      }
     }
   ' "${readme_path}"
 } | perl -pe 's{<t([dh])\b(?![^>]*\bmarkdown=)([^>]*)>}{<t$1 markdown="1"$2>}g' > "${output_path}"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Generally speaking, installation / usage follows these steps:
 3. Start a DM with the bot `@componentnamebot:example.com`, i.e. `@whatsappbot:example.com`, login etc.
 
 > [!TIP]
-> You should start with the [INSTALLATION](INSTALLATION.md) guide!.
+> You should start with the [INSTALLATION](INSTALLATION.md) guide!
 
 ### OCI Registry (Preferred)
 


### PR DESCRIPTION
The static site does not render markdown within the table tags like Githubs repo README, this PR fixes that and also converts GitHub markdown callouts too.