### PR TITLE
Better Postgres Password Handling

### DIFF
--- a/charts/matrix-appservice-irc/Chart.yaml
+++ b/charts/matrix-appservice-irc/Chart.yaml
@@ -5,5 +5,5 @@ home: https://matrix-org.github.io/matrix-appservice-irc/latest/
 sources:
   - https://github.com/matrix-org/matrix-appservice-irc
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "release-4.0.0"

--- a/charts/matrix-appservice-irc/README.md
+++ b/charts/matrix-appservice-irc/README.md
@@ -205,6 +205,8 @@ synapse:
 
 Ready-to-use file: `values.external.example.yaml`
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Equivalent inline values:
 
 ```yaml

--- a/charts/matrix-appservice-irc/README.md
+++ b/charts/matrix-appservice-irc/README.md
@@ -224,7 +224,8 @@ database:
     user: matrix_irc
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: matrix_irc
     sslMode: prefer

--- a/charts/matrix-appservice-irc/README.md
+++ b/charts/matrix-appservice-irc/README.md
@@ -205,7 +205,9 @@ synapse:
 
 Ready-to-use file: `values.external.example.yaml`
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Equivalent inline values:
 
@@ -222,6 +224,8 @@ database:
     user: matrix_irc
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: matrix_irc
     sslMode: prefer
 ```

--- a/charts/matrix-appservice-irc/templates/_helpers.tpl
+++ b/charts/matrix-appservice-irc/templates/_helpers.tpl
@@ -210,11 +210,32 @@ app.kubernetes.io/component: {{ .component }}
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
-{{- define "matrix-appservice-irc.databasePostgresPassword" -}}
+{{- define "matrix-appservice-irc.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
+{{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
-{{- required "values.database.postgres.password.value is required" $password -}}
+{{- if eq $password "" -}}
+{{- if .Values.postgres.enabled -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "matrix-appservice-irc.postgresFullname" .) -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "POSTGRES_PASSWORD") -}}
+{{- $password = (index $existing.data "POSTGRES_PASSWORD" | b64dec) -}}
+{{- else -}}
+{{- $password = (randAlphaNum 64 | sha256sum) -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $password "" -}}
+{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- else -}}
+{{- $_ := set $postgres "_computedPassword" $password -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matrix-appservice-irc.databasePostgresPassword" -}}
+{{- include "matrix-appservice-irc.ensureDatabasePostgresPassword" . -}}
+{{- index .Values.database.postgres "_computedPassword" -}}
 {{- end -}}
 
 {{- define "matrix-appservice-irc.redisUrl" -}}

--- a/charts/matrix-appservice-irc/templates/_helpers.tpl
+++ b/charts/matrix-appservice-irc/templates/_helpers.tpl
@@ -239,22 +239,8 @@ POSTGRES_PASSWORD
 {{- define "matrix-appservice-irc.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
-{{- $passwordCfg := (get $postgres "password") | default dict -}}
-{{- $password := (get $passwordCfg "value") | default "" -}}
-{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
-{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
-{{- if and (ne $password "") (ne $existingSecretName "") -}}
-{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
-{{- end -}}
-{{- if eq $password "" -}}
-{{- if ne $existingSecretName "" -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
-{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
-{{- else -}}
-{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
-{{- end -}}
-{{- else if .Values.postgres.enabled -}}
+{{- $password := "" -}}
+{{- if .Values.postgres.enabled -}}
 {{- $managedSecretName := include "matrix-appservice-irc.postgresFullname" . -}}
 {{- $managedSecretKey := include "matrix-appservice-irc.databasePostgresManagedSecretKey" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
@@ -266,16 +252,33 @@ POSTGRES_PASSWORD
 {{- end -}}
 {{- if eq $password "" -}}
 {{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
-{{- else -}}
+{{- end -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "matrix-appservice-irc.databasePostgresPassword" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if ne $password "" -}}
+{{- $password -}}
+{{- else if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- index $existing.data $existingSecretKey | b64dec -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else -}}
 {{- include "matrix-appservice-irc.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "matrix-appservice-irc.databasePostgresPasswordChecksum" -}}

--- a/charts/matrix-appservice-irc/templates/_helpers.tpl
+++ b/charts/matrix-appservice-irc/templates/_helpers.tpl
@@ -210,22 +210,62 @@ app.kubernetes.io/component: {{ .component }}
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
+{{- define "matrix-appservice-irc.databasePostgresManagedSecretKey" -}}
+POSTGRES_PASSWORD
+{{- end -}}
+
+{{- define "matrix-appservice-irc.databasePostgresPasswordSecretName" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existingSecretName -}}
+{{- else -}}
+{{- include "matrix-appservice-irc.postgresFullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matrix-appservice-irc.databasePostgresPasswordSecretKey" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- else -}}
+{{- include "matrix-appservice-irc.databasePostgresManagedSecretKey" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "matrix-appservice-irc.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
 {{- if eq $password "" -}}
-{{- if .Values.postgres.enabled -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "matrix-appservice-irc.postgresFullname" .) -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "POSTGRES_PASSWORD") -}}
-{{- $password = (index $existing.data "POSTGRES_PASSWORD" | b64dec) -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else if .Values.postgres.enabled -}}
+{{- $managedSecretName := include "matrix-appservice-irc.postgresFullname" . -}}
+{{- $managedSecretKey := include "matrix-appservice-irc.databasePostgresManagedSecretKey" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $managedSecretKey) -}}
+{{- $password = (index $existing.data $managedSecretKey | b64dec) -}}
 {{- else -}}
 {{- $password = (randAlphaNum 64 | sha256sum) -}}
 {{- end -}}
 {{- end -}}
 {{- if eq $password "" -}}
-{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
 {{- else -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
 {{- end -}}
@@ -236,6 +276,16 @@ app.kubernetes.io/component: {{ .component }}
 {{- define "matrix-appservice-irc.databasePostgresPassword" -}}
 {{- include "matrix-appservice-irc.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
+
+{{- define "matrix-appservice-irc.databasePostgresPasswordChecksum" -}}
+{{- include "matrix-appservice-irc.ensureDatabasePostgresPassword" . -}}
+{{- $payload := dict
+  "secretName" (include "matrix-appservice-irc.databasePostgresPasswordSecretName" .)
+  "secretKey" (include "matrix-appservice-irc.databasePostgresPasswordSecretKey" .)
+  "password" (include "matrix-appservice-irc.databasePostgresPassword" .)
+-}}
+{{- toYaml $payload | sha256sum -}}
 {{- end -}}
 
 {{- define "matrix-appservice-irc.redisUrl" -}}

--- a/charts/matrix-appservice-irc/templates/postgres-secret.yaml
+++ b/charts/matrix-appservice-irc/templates/postgres-secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.postgres.enabled }}
+{{- $passwordCfg := (get (.Values.database.postgres | default dict) "password") | default dict -}}
+{{- if and .Values.postgres.enabled (eq ((get $passwordCfg "existingSecret") | default "") "") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/matrix-appservice-irc/templates/postgres-statefulset.yaml
+++ b/charts/matrix-appservice-irc/templates/postgres-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         {{- include "matrix-appservice-irc.componentSelectorLabels" (dict "context" . "component" "postgres") | nindent 8 }}
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/postgres-secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include "matrix-appservice-irc.databasePostgresPasswordChecksum" . }}
     spec:
       {{- if .Values.postgres.podSecurityContext.enabled }}
       {{- $podSecurityContext := omit .Values.postgres.podSecurityContext "enabled" }}
@@ -41,20 +41,14 @@ spec:
               containerPort: {{ .Values.postgres.service.port }}
           env:
             - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "matrix-appservice-irc.postgresFullname" . }}
-                  key: POSTGRES_DB
+              value: {{ include "matrix-appservice-irc.databasePostgresDatabase" . | quote }}
             - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "matrix-appservice-irc.postgresFullname" . }}
-                  key: POSTGRES_USER
+              value: {{ include "matrix-appservice-irc.databasePostgresUser" . | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "matrix-appservice-irc.postgresFullname" . }}
-                  key: POSTGRES_PASSWORD
+                  name: {{ include "matrix-appservice-irc.databasePostgresPasswordSecretName" . }}
+                  key: {{ include "matrix-appservice-irc.databasePostgresPasswordSecretKey" . }}
           {{- with .Values.postgres.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/matrix-appservice-irc/values.external.example.yaml
+++ b/charts/matrix-appservice-irc/values.external.example.yaml
@@ -25,5 +25,7 @@ database:
     user: matrix_irc
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: matrix_irc
     sslMode: prefer

--- a/charts/matrix-appservice-irc/values.external.example.yaml
+++ b/charts/matrix-appservice-irc/values.external.example.yaml
@@ -25,7 +25,8 @@ database:
     user: matrix_irc
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: matrix_irc
     sslMode: prefer

--- a/charts/matrix-appservice-irc/values.schema.json
+++ b/charts/matrix-appservice-irc/values.schema.json
@@ -339,7 +339,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "matrix_irc_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/matrix-appservice-irc/values.schema.json
+++ b/charts/matrix-appservice-irc/values.schema.json
@@ -339,7 +339,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/matrix-appservice-irc/values.secrets.yaml
+++ b/charts/matrix-appservice-irc/values.secrets.yaml
@@ -33,3 +33,10 @@ mediaProxy:
   managedSecret:
     enabled: false
   autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: matrix-appservice-irc-postgres-password
+#       existingSecretKey: password

--- a/charts/matrix-appservice-irc/values.yaml
+++ b/charts/matrix-appservice-irc/values.yaml
@@ -104,7 +104,8 @@ database:
     port: 5432
     user: matrix_irc
     password:
-      value: matrix_irc_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: matrix_irc
     sslMode: prefer
 

--- a/charts/matrix-appservice-irc/values.yaml
+++ b/charts/matrix-appservice-irc/values.yaml
@@ -106,6 +106,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: matrix_irc
     sslMode: prefer
 

--- a/charts/mautrix-bluesky/Chart.lock
+++ b/charts/mautrix-bluesky/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:05.7181954Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.906735Z"

--- a/charts/mautrix-bluesky/Chart.yaml
+++ b/charts/mautrix-bluesky/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/bluesky/
 sources:
   - https://github.com/mautrix/bluesky
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2510.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_bluesky
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_bluesky
     sslMode: require
 ```

--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_bluesky
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_bluesky
     sslMode: require

--- a/charts/mautrix-bluesky/values.external.example.yaml
+++ b/charts/mautrix-bluesky/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_bluesky
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_bluesky
     sslMode: require
 

--- a/charts/mautrix-bluesky/values.external.example.yaml
+++ b/charts/mautrix-bluesky/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_bluesky
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_bluesky
     sslMode: require

--- a/charts/mautrix-bluesky/values.schema.json
+++ b/charts/mautrix-bluesky/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-bluesky/values.schema.json
+++ b/charts/mautrix-bluesky/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_bluesky_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-bluesky/values.secrets.yaml
+++ b/charts/mautrix-bluesky/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-bluesky-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-bluesky/values.yaml
+++ b/charts/mautrix-bluesky/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_bluesky
     password:
-      value: mautrix_bluesky_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_bluesky
     sslMode: disable
 

--- a/charts/mautrix-bluesky/values.yaml
+++ b/charts/mautrix-bluesky/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_bluesky
     sslMode: disable
 

--- a/charts/mautrix-gmessages/Chart.lock
+++ b/charts/mautrix-gmessages/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:05.9337513Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.906469Z"

--- a/charts/mautrix-gmessages/Chart.yaml
+++ b/charts/mautrix-gmessages/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/gmessages/
 sources:
   - https://github.com/mautrix/gmessages
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_gmessages
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_gmessages
     sslMode: require
 ```

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_gmessages
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gmessages
     sslMode: require

--- a/charts/mautrix-gmessages/values.external.example.yaml
+++ b/charts/mautrix-gmessages/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_gmessages
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_gmessages
     sslMode: require
 

--- a/charts/mautrix-gmessages/values.external.example.yaml
+++ b/charts/mautrix-gmessages/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_gmessages
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gmessages
     sslMode: require

--- a/charts/mautrix-gmessages/values.schema.json
+++ b/charts/mautrix-gmessages/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-gmessages/values.schema.json
+++ b/charts/mautrix-gmessages/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_gmessages_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-gmessages/values.secrets.yaml
+++ b/charts/mautrix-gmessages/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-gmessages-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-gmessages/values.yaml
+++ b/charts/mautrix-gmessages/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_gmessages
     password:
-      value: mautrix_gmessages_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_gmessages
     sslMode: disable
 

--- a/charts/mautrix-gmessages/values.yaml
+++ b/charts/mautrix-gmessages/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_gmessages
     sslMode: disable
 

--- a/charts/mautrix-go-base/Chart.yaml
+++ b/charts/mautrix-go-base/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/mautrix
   - https://github.com/cyclikal94/matrix-helm-charts
 type: library
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.0.0"

--- a/charts/mautrix-go-base/templates/_helpers.tpl
+++ b/charts/mautrix-go-base/templates/_helpers.tpl
@@ -100,11 +100,32 @@ app.kubernetes.io/component: {{ .component }}
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
-{{- define "mautrix-go-base.databasePostgresPassword" -}}
+{{- define "mautrix-go-base.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
+{{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
-{{- required "values.database.postgres.password.value is required" $password -}}
+{{- if eq $password "" -}}
+{{- if .Values.postgres.enabled -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "mautrix-go-base.postgresFullname" .) -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "password") -}}
+{{- $password = (index $existing.data "password" | b64dec) -}}
+{{- else -}}
+{{- $password = (randAlphaNum 64 | sha256sum) -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $password "" -}}
+{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- else -}}
+{{- $_ := set $postgres "_computedPassword" $password -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mautrix-go-base.databasePostgresPassword" -}}
+{{- include "mautrix-go-base.ensureDatabasePostgresPassword" . -}}
+{{- index .Values.database.postgres "_computedPassword" -}}
 {{- end -}}
 
 {{- define "mautrix-go-base.databaseConnectionString" -}}

--- a/charts/mautrix-go-base/templates/_helpers.tpl
+++ b/charts/mautrix-go-base/templates/_helpers.tpl
@@ -100,22 +100,62 @@ app.kubernetes.io/component: {{ .component }}
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
+{{- define "mautrix-go-base.databasePostgresManagedSecretKey" -}}
+password
+{{- end -}}
+
+{{- define "mautrix-go-base.databasePostgresPasswordSecretName" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existingSecretName -}}
+{{- else -}}
+{{- include "mautrix-go-base.postgresFullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mautrix-go-base.databasePostgresPasswordSecretKey" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- else -}}
+{{- include "mautrix-go-base.databasePostgresManagedSecretKey" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mautrix-go-base.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
 {{- if eq $password "" -}}
-{{- if .Values.postgres.enabled -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "mautrix-go-base.postgresFullname" .) -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "password") -}}
-{{- $password = (index $existing.data "password" | b64dec) -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else if .Values.postgres.enabled -}}
+{{- $managedSecretName := include "mautrix-go-base.postgresFullname" . -}}
+{{- $managedSecretKey := include "mautrix-go-base.databasePostgresManagedSecretKey" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $managedSecretKey) -}}
+{{- $password = (index $existing.data $managedSecretKey | b64dec) -}}
 {{- else -}}
 {{- $password = (randAlphaNum 64 | sha256sum) -}}
 {{- end -}}
 {{- end -}}
 {{- if eq $password "" -}}
-{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
 {{- else -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
 {{- end -}}
@@ -126,6 +166,16 @@ app.kubernetes.io/component: {{ .component }}
 {{- define "mautrix-go-base.databasePostgresPassword" -}}
 {{- include "mautrix-go-base.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
+
+{{- define "mautrix-go-base.databasePostgresPasswordChecksum" -}}
+{{- include "mautrix-go-base.ensureDatabasePostgresPassword" . -}}
+{{- $payload := dict
+  "secretName" (include "mautrix-go-base.databasePostgresPasswordSecretName" .)
+  "secretKey" (include "mautrix-go-base.databasePostgresPasswordSecretKey" .)
+  "password" (include "mautrix-go-base.databasePostgresPassword" .)
+-}}
+{{- toYaml $payload | sha256sum -}}
 {{- end -}}
 
 {{- define "mautrix-go-base.databaseConnectionString" -}}

--- a/charts/mautrix-go-base/templates/_helpers.tpl
+++ b/charts/mautrix-go-base/templates/_helpers.tpl
@@ -129,22 +129,8 @@ password
 {{- define "mautrix-go-base.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
-{{- $passwordCfg := (get $postgres "password") | default dict -}}
-{{- $password := (get $passwordCfg "value") | default "" -}}
-{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
-{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
-{{- if and (ne $password "") (ne $existingSecretName "") -}}
-{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
-{{- end -}}
-{{- if eq $password "" -}}
-{{- if ne $existingSecretName "" -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
-{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
-{{- else -}}
-{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
-{{- end -}}
-{{- else if .Values.postgres.enabled -}}
+{{- $password := "" -}}
+{{- if .Values.postgres.enabled -}}
 {{- $managedSecretName := include "mautrix-go-base.postgresFullname" . -}}
 {{- $managedSecretKey := include "mautrix-go-base.databasePostgresManagedSecretKey" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
@@ -156,16 +142,33 @@ password
 {{- end -}}
 {{- if eq $password "" -}}
 {{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
-{{- else -}}
+{{- end -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "mautrix-go-base.databasePostgresPassword" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if ne $password "" -}}
+{{- $password -}}
+{{- else if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- index $existing.data $existingSecretKey | b64dec -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else -}}
 {{- include "mautrix-go-base.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mautrix-go-base.databasePostgresPasswordChecksum" -}}

--- a/charts/mautrix-go-base/templates/_render.tpl
+++ b/charts/mautrix-go-base/templates/_render.tpl
@@ -231,7 +231,8 @@ data:
 {{- end -}}
 
 {{- define "mautrix-go-base.postgresSecret" -}}
-{{- if .Values.postgres.enabled }}
+{{- $passwordCfg := (get (.Values.database.postgres | default dict) "password") | default dict -}}
+{{- if and .Values.postgres.enabled (eq ((get $passwordCfg "existingSecret") | default "") "") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -282,7 +283,7 @@ spec:
       labels:
         {{- include "mautrix-go-base.componentSelectorLabels" (dict "context" . "component" "postgres") | nindent 8 }}
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/postgres-secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include "mautrix-go-base.databasePostgresPasswordChecksum" . }}
     spec:
       {{- if .Values.postgres.podSecurityContext.enabled }}
       {{- $podSecurityContext := omit .Values.postgres.podSecurityContext "enabled" }}
@@ -310,8 +311,8 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mautrix-go-base.postgresFullname" . }}
-                  key: password
+                  name: {{ include "mautrix-go-base.databasePostgresPasswordSecretName" . }}
+                  key: {{ include "mautrix-go-base.databasePostgresPasswordSecretKey" . }}
           ports:
             - name: postgres
               containerPort: {{ .Values.postgres.service.port }}

--- a/charts/mautrix-googlechat/Chart.yaml
+++ b/charts/mautrix-googlechat/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/googlechat/
 sources:
   - https://github.com/mautrix/googlechat
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.5.2"

--- a/charts/mautrix-googlechat/README.md
+++ b/charts/mautrix-googlechat/README.md
@@ -127,6 +127,8 @@ If `config.extra` overlaps any managed path, template rendering fails.
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-googlechat/README.md
+++ b/charts/mautrix-googlechat/README.md
@@ -144,7 +144,8 @@ database:
     user: mautrix_googlechat
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_googlechat
     sslMode: require

--- a/charts/mautrix-googlechat/README.md
+++ b/charts/mautrix-googlechat/README.md
@@ -127,7 +127,9 @@ If `config.extra` overlaps any managed path, template rendering fails.
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -142,6 +144,8 @@ database:
     user: mautrix_googlechat
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_googlechat
     sslMode: require
 ```

--- a/charts/mautrix-googlechat/templates/_helpers.tpl
+++ b/charts/mautrix-googlechat/templates/_helpers.tpl
@@ -94,11 +94,32 @@ appservice-registration-googlechat.yaml
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
-{{- define "mautrix-googlechat.databasePostgresPassword" -}}
+{{- define "mautrix-googlechat.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
+{{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
-{{- required "values.database.postgres.password.value is required" $password -}}
+{{- if eq $password "" -}}
+{{- if .Values.postgres.enabled -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "mautrix-googlechat.postgresFullname" .) -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "password") -}}
+{{- $password = (index $existing.data "password" | b64dec) -}}
+{{- else -}}
+{{- $password = (randAlphaNum 64 | sha256sum) -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $password "" -}}
+{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- else -}}
+{{- $_ := set $postgres "_computedPassword" $password -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mautrix-googlechat.databasePostgresPassword" -}}
+{{- include "mautrix-googlechat.ensureDatabasePostgresPassword" . -}}
+{{- index .Values.database.postgres "_computedPassword" -}}
 {{- end -}}
 
 {{- define "mautrix-googlechat.databaseConnectionString" -}}

--- a/charts/mautrix-googlechat/templates/_helpers.tpl
+++ b/charts/mautrix-googlechat/templates/_helpers.tpl
@@ -123,22 +123,8 @@ password
 {{- define "mautrix-googlechat.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
-{{- $passwordCfg := (get $postgres "password") | default dict -}}
-{{- $password := (get $passwordCfg "value") | default "" -}}
-{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
-{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
-{{- if and (ne $password "") (ne $existingSecretName "") -}}
-{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
-{{- end -}}
-{{- if eq $password "" -}}
-{{- if ne $existingSecretName "" -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
-{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
-{{- else -}}
-{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
-{{- end -}}
-{{- else if .Values.postgres.enabled -}}
+{{- $password := "" -}}
+{{- if .Values.postgres.enabled -}}
 {{- $managedSecretName := include "mautrix-googlechat.postgresFullname" . -}}
 {{- $managedSecretKey := include "mautrix-googlechat.databasePostgresManagedSecretKey" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
@@ -150,16 +136,33 @@ password
 {{- end -}}
 {{- if eq $password "" -}}
 {{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
-{{- else -}}
+{{- end -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "mautrix-googlechat.databasePostgresPassword" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if ne $password "" -}}
+{{- $password -}}
+{{- else if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- index $existing.data $existingSecretKey | b64dec -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else -}}
 {{- include "mautrix-googlechat.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mautrix-googlechat.databasePostgresPasswordChecksum" -}}

--- a/charts/mautrix-googlechat/templates/_helpers.tpl
+++ b/charts/mautrix-googlechat/templates/_helpers.tpl
@@ -94,22 +94,62 @@ appservice-registration-googlechat.yaml
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
+{{- define "mautrix-googlechat.databasePostgresManagedSecretKey" -}}
+password
+{{- end -}}
+
+{{- define "mautrix-googlechat.databasePostgresPasswordSecretName" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existingSecretName -}}
+{{- else -}}
+{{- include "mautrix-googlechat.postgresFullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mautrix-googlechat.databasePostgresPasswordSecretKey" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- else -}}
+{{- include "mautrix-googlechat.databasePostgresManagedSecretKey" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mautrix-googlechat.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
 {{- if eq $password "" -}}
-{{- if .Values.postgres.enabled -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "mautrix-googlechat.postgresFullname" .) -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "password") -}}
-{{- $password = (index $existing.data "password" | b64dec) -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else if .Values.postgres.enabled -}}
+{{- $managedSecretName := include "mautrix-googlechat.postgresFullname" . -}}
+{{- $managedSecretKey := include "mautrix-googlechat.databasePostgresManagedSecretKey" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $managedSecretKey) -}}
+{{- $password = (index $existing.data $managedSecretKey | b64dec) -}}
 {{- else -}}
 {{- $password = (randAlphaNum 64 | sha256sum) -}}
 {{- end -}}
 {{- end -}}
 {{- if eq $password "" -}}
-{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
 {{- else -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
 {{- end -}}
@@ -120,6 +160,16 @@ appservice-registration-googlechat.yaml
 {{- define "mautrix-googlechat.databasePostgresPassword" -}}
 {{- include "mautrix-googlechat.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
+
+{{- define "mautrix-googlechat.databasePostgresPasswordChecksum" -}}
+{{- include "mautrix-googlechat.ensureDatabasePostgresPassword" . -}}
+{{- $payload := dict
+  "secretName" (include "mautrix-googlechat.databasePostgresPasswordSecretName" .)
+  "secretKey" (include "mautrix-googlechat.databasePostgresPasswordSecretKey" .)
+  "password" (include "mautrix-googlechat.databasePostgresPassword" .)
+-}}
+{{- toYaml $payload | sha256sum -}}
 {{- end -}}
 
 {{- define "mautrix-googlechat.databaseConnectionString" -}}

--- a/charts/mautrix-googlechat/templates/postgres-secret.yaml
+++ b/charts/mautrix-googlechat/templates/postgres-secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.postgres.enabled }}
+{{- $passwordCfg := (get (.Values.database.postgres | default dict) "password") | default dict -}}
+{{- if and .Values.postgres.enabled (eq ((get $passwordCfg "existingSecret") | default "") "") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/mautrix-googlechat/templates/postgres-statefulset.yaml
+++ b/charts/mautrix-googlechat/templates/postgres-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         {{- include "mautrix-googlechat.componentSelectorLabels" (dict "context" . "component" "postgres") | nindent 8 }}
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/postgres-secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include "mautrix-googlechat.databasePostgresPasswordChecksum" . }}
     spec:
       {{- if .Values.postgres.podSecurityContext.enabled }}
       {{- $podSecurityContext := omit .Values.postgres.podSecurityContext "enabled" }}
@@ -44,8 +44,8 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mautrix-googlechat.postgresFullname" . }}
-                  key: password
+                  name: {{ include "mautrix-googlechat.databasePostgresPasswordSecretName" . }}
+                  key: {{ include "mautrix-googlechat.databasePostgresPasswordSecretKey" . }}
           ports:
             - name: postgres
               containerPort: {{ .Values.postgres.service.port }}

--- a/charts/mautrix-googlechat/values.external.example.yaml
+++ b/charts/mautrix-googlechat/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_googlechat
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_googlechat
     sslMode: require

--- a/charts/mautrix-googlechat/values.external.example.yaml
+++ b/charts/mautrix-googlechat/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_googlechat
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_googlechat
     sslMode: require
 

--- a/charts/mautrix-googlechat/values.schema.json
+++ b/charts/mautrix-googlechat/values.schema.json
@@ -251,7 +251,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_googlechat_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-googlechat/values.schema.json
+++ b/charts/mautrix-googlechat/values.schema.json
@@ -251,7 +251,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-googlechat/values.secrets.yaml
+++ b/charts/mautrix-googlechat/values.secrets.yaml
@@ -19,3 +19,10 @@ registration:
   managedSecret:
     enabled: false
   autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-googlechat-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-googlechat/values.yaml
+++ b/charts/mautrix-googlechat/values.yaml
@@ -92,7 +92,8 @@ database:
     port: 5432
     user: mautrix_googlechat
     password:
-      value: mautrix_googlechat_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_googlechat
     sslMode: disable
 

--- a/charts/mautrix-googlechat/values.yaml
+++ b/charts/mautrix-googlechat/values.yaml
@@ -94,6 +94,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_googlechat
     sslMode: disable
 

--- a/charts/mautrix-gvoice/Chart.lock
+++ b/charts/mautrix-gvoice/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:06.1388541Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.90726Z"

--- a/charts/mautrix-gvoice/Chart.yaml
+++ b/charts/mautrix-gvoice/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/gvoice/
 sources:
   - https://github.com/mautrix/gvoice
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_gvoice
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_gvoice
     sslMode: require
 ```

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_gvoice
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gvoice
     sslMode: require

--- a/charts/mautrix-gvoice/values.external.example.yaml
+++ b/charts/mautrix-gvoice/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_gvoice
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_gvoice
     sslMode: require
 

--- a/charts/mautrix-gvoice/values.external.example.yaml
+++ b/charts/mautrix-gvoice/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_gvoice
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gvoice
     sslMode: require

--- a/charts/mautrix-gvoice/values.schema.json
+++ b/charts/mautrix-gvoice/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-gvoice/values.schema.json
+++ b/charts/mautrix-gvoice/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_gvoice_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-gvoice/values.secrets.yaml
+++ b/charts/mautrix-gvoice/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-gvoice-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-gvoice/values.yaml
+++ b/charts/mautrix-gvoice/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_gvoice
     sslMode: disable
 

--- a/charts/mautrix-gvoice/values.yaml
+++ b/charts/mautrix-gvoice/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_gvoice
     password:
-      value: mautrix_gvoice_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_gvoice
     sslMode: disable
 

--- a/charts/mautrix-linkedin/Chart.lock
+++ b/charts/mautrix-linkedin/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:06.3410611Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.907131Z"

--- a/charts/mautrix-linkedin/Chart.yaml
+++ b/charts/mautrix-linkedin/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/linkedin/
 sources:
   - https://github.com/mautrix/linkedin
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_linkedin
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_linkedin
     sslMode: require
 ```

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_linkedin
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_linkedin
     sslMode: require

--- a/charts/mautrix-linkedin/values.external.example.yaml
+++ b/charts/mautrix-linkedin/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_linkedin
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_linkedin
     sslMode: require
 

--- a/charts/mautrix-linkedin/values.external.example.yaml
+++ b/charts/mautrix-linkedin/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_linkedin
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_linkedin
     sslMode: require

--- a/charts/mautrix-linkedin/values.schema.json
+++ b/charts/mautrix-linkedin/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-linkedin/values.schema.json
+++ b/charts/mautrix-linkedin/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_linkedin_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-linkedin/values.secrets.yaml
+++ b/charts/mautrix-linkedin/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-linkedin-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-linkedin/values.yaml
+++ b/charts/mautrix-linkedin/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_linkedin
     sslMode: disable
 

--- a/charts/mautrix-linkedin/values.yaml
+++ b/charts/mautrix-linkedin/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_linkedin
     password:
-      value: mautrix_linkedin_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_linkedin
     sslMode: disable
 

--- a/charts/mautrix-meta/Chart.lock
+++ b/charts/mautrix-meta/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:06.5461775Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.90632Z"

--- a/charts/mautrix-meta/Chart.yaml
+++ b/charts/mautrix-meta/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/meta/
 sources:
   - https://github.com/mautrix/meta
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_meta
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_meta
     sslMode: require
 ```

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_meta
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_meta
     sslMode: require

--- a/charts/mautrix-meta/values.external.example.yaml
+++ b/charts/mautrix-meta/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_meta
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_meta
     sslMode: require
 

--- a/charts/mautrix-meta/values.external.example.yaml
+++ b/charts/mautrix-meta/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_meta
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_meta
     sslMode: require

--- a/charts/mautrix-meta/values.schema.json
+++ b/charts/mautrix-meta/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-meta/values.schema.json
+++ b/charts/mautrix-meta/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_meta_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-meta/values.secrets.yaml
+++ b/charts/mautrix-meta/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-meta-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-meta/values.yaml
+++ b/charts/mautrix-meta/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_meta
     password:
-      value: mautrix_meta_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_meta
     sslMode: disable
 

--- a/charts/mautrix-meta/values.yaml
+++ b/charts/mautrix-meta/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_meta
     sslMode: disable
 

--- a/charts/mautrix-signal/Chart.lock
+++ b/charts/mautrix-signal/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:06.7528697Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.905922Z"

--- a/charts/mautrix-signal/Chart.yaml
+++ b/charts/mautrix-signal/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/signal/
 sources:
   - https://github.com/mautrix/signal
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.2"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_signal
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_signal
     sslMode: require
 ```

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_signal
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_signal
     sslMode: require

--- a/charts/mautrix-signal/values.external.example.yaml
+++ b/charts/mautrix-signal/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_signal
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_signal
     sslMode: require
 

--- a/charts/mautrix-signal/values.external.example.yaml
+++ b/charts/mautrix-signal/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_signal
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_signal
     sslMode: require

--- a/charts/mautrix-signal/values.schema.json
+++ b/charts/mautrix-signal/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-signal/values.schema.json
+++ b/charts/mautrix-signal/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_signal_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-signal/values.secrets.yaml
+++ b/charts/mautrix-signal/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-signal-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-signal/values.yaml
+++ b/charts/mautrix-signal/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_signal
     password:
-      value: mautrix_signal_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_signal
     sslMode: disable
 

--- a/charts/mautrix-signal/values.yaml
+++ b/charts/mautrix-signal/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_signal
     sslMode: disable
 

--- a/charts/mautrix-slack/Chart.lock
+++ b/charts/mautrix-slack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:06.9708255Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.905942Z"

--- a/charts/mautrix-slack/Chart.yaml
+++ b/charts/mautrix-slack/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/slack/
 sources:
   - https://github.com/mautrix/slack
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_slack
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_slack
     sslMode: require
 ```

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_slack
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_slack
     sslMode: require

--- a/charts/mautrix-slack/values.external.example.yaml
+++ b/charts/mautrix-slack/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_slack
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_slack
     sslMode: require
 

--- a/charts/mautrix-slack/values.external.example.yaml
+++ b/charts/mautrix-slack/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_slack
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_slack
     sslMode: require

--- a/charts/mautrix-slack/values.schema.json
+++ b/charts/mautrix-slack/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_slack_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-slack/values.schema.json
+++ b/charts/mautrix-slack/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-slack/values.secrets.yaml
+++ b/charts/mautrix-slack/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-slack-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-slack/values.yaml
+++ b/charts/mautrix-slack/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_slack
     sslMode: disable
 

--- a/charts/mautrix-slack/values.yaml
+++ b/charts/mautrix-slack/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_slack
     password:
-      value: mautrix_slack_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_slack
     sslMode: disable
 

--- a/charts/mautrix-telegram/Chart.yaml
+++ b/charts/mautrix-telegram/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/telegram/
 sources:
   - https://github.com/mautrix/telegram
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.15.3"

--- a/charts/mautrix-telegram/README.md
+++ b/charts/mautrix-telegram/README.md
@@ -135,6 +135,8 @@ If `config.extra` overlaps any managed path, template rendering fails.
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-telegram/README.md
+++ b/charts/mautrix-telegram/README.md
@@ -152,7 +152,8 @@ database:
     user: mautrix_telegram
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_telegram
     sslMode: require

--- a/charts/mautrix-telegram/README.md
+++ b/charts/mautrix-telegram/README.md
@@ -135,7 +135,9 @@ If `config.extra` overlaps any managed path, template rendering fails.
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -150,6 +152,8 @@ database:
     user: mautrix_telegram
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_telegram
     sslMode: require
 ```

--- a/charts/mautrix-telegram/templates/_helpers.tpl
+++ b/charts/mautrix-telegram/templates/_helpers.tpl
@@ -106,11 +106,32 @@ appservice-registration-telegram.yaml
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
-{{- define "mautrix-telegram.databasePostgresPassword" -}}
+{{- define "mautrix-telegram.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
+{{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
-{{- required "values.database.postgres.password.value is required" $password -}}
+{{- if eq $password "" -}}
+{{- if .Values.postgres.enabled -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "mautrix-telegram.postgresFullname" .) -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "password") -}}
+{{- $password = (index $existing.data "password" | b64dec) -}}
+{{- else -}}
+{{- $password = (randAlphaNum 64 | sha256sum) -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $password "" -}}
+{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- else -}}
+{{- $_ := set $postgres "_computedPassword" $password -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mautrix-telegram.databasePostgresPassword" -}}
+{{- include "mautrix-telegram.ensureDatabasePostgresPassword" . -}}
+{{- index .Values.database.postgres "_computedPassword" -}}
 {{- end -}}
 
 {{- define "mautrix-telegram.databaseConnectionString" -}}

--- a/charts/mautrix-telegram/templates/_helpers.tpl
+++ b/charts/mautrix-telegram/templates/_helpers.tpl
@@ -135,22 +135,8 @@ password
 {{- define "mautrix-telegram.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
-{{- $passwordCfg := (get $postgres "password") | default dict -}}
-{{- $password := (get $passwordCfg "value") | default "" -}}
-{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
-{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
-{{- if and (ne $password "") (ne $existingSecretName "") -}}
-{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
-{{- end -}}
-{{- if eq $password "" -}}
-{{- if ne $existingSecretName "" -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
-{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
-{{- else -}}
-{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
-{{- end -}}
-{{- else if .Values.postgres.enabled -}}
+{{- $password := "" -}}
+{{- if .Values.postgres.enabled -}}
 {{- $managedSecretName := include "mautrix-telegram.postgresFullname" . -}}
 {{- $managedSecretKey := include "mautrix-telegram.databasePostgresManagedSecretKey" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
@@ -162,16 +148,33 @@ password
 {{- end -}}
 {{- if eq $password "" -}}
 {{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
-{{- else -}}
+{{- end -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
-{{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "mautrix-telegram.databasePostgresPassword" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if ne $password "" -}}
+{{- $password -}}
+{{- else if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- index $existing.data $existingSecretKey | b64dec -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else -}}
 {{- include "mautrix-telegram.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mautrix-telegram.databasePostgresPasswordChecksum" -}}

--- a/charts/mautrix-telegram/templates/_helpers.tpl
+++ b/charts/mautrix-telegram/templates/_helpers.tpl
@@ -106,22 +106,62 @@ appservice-registration-telegram.yaml
 {{- required "values.database.postgres.user is required" $user -}}
 {{- end -}}
 
+{{- define "mautrix-telegram.databasePostgresManagedSecretKey" -}}
+password
+{{- end -}}
+
+{{- define "mautrix-telegram.databasePostgresPasswordSecretName" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existingSecretName -}}
+{{- else -}}
+{{- include "mautrix-telegram.postgresFullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mautrix-telegram.databasePostgresPasswordSecretKey" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if ne $existingSecretName "" -}}
+{{- (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- else -}}
+{{- include "mautrix-telegram.databasePostgresManagedSecretKey" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mautrix-telegram.ensureDatabasePostgresPassword" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- if not (hasKey $postgres "_computedPassword") -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
 {{- if eq $password "" -}}
-{{- if .Values.postgres.enabled -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "mautrix-telegram.postgresFullname" .) -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data "password") -}}
-{{- $password = (index $existing.data "password" | b64dec) -}}
+{{- if ne $existingSecretName "" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
+{{- $password = (index $existing.data $existingSecretKey | b64dec) -}}
+{{- else -}}
+{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
+{{- end -}}
+{{- else if .Values.postgres.enabled -}}
+{{- $managedSecretName := include "mautrix-telegram.postgresFullname" . -}}
+{{- $managedSecretKey := include "mautrix-telegram.databasePostgresManagedSecretKey" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $managedSecretName -}}
+{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $managedSecretKey) -}}
+{{- $password = (index $existing.data $managedSecretKey | b64dec) -}}
 {{- else -}}
 {{- $password = (randAlphaNum 64 | sha256sum) -}}
 {{- end -}}
 {{- end -}}
 {{- if eq $password "" -}}
-{{- fail "values.database.postgres.password.value is required when postgres.enabled=false" -}}
+{{- fail "values.database.postgres.password.value or values.database.postgres.password.existingSecret is required when postgres.enabled=false" -}}
 {{- else -}}
 {{- $_ := set $postgres "_computedPassword" $password -}}
 {{- end -}}
@@ -132,6 +172,16 @@ appservice-registration-telegram.yaml
 {{- define "mautrix-telegram.databasePostgresPassword" -}}
 {{- include "mautrix-telegram.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
+{{- end -}}
+
+{{- define "mautrix-telegram.databasePostgresPasswordChecksum" -}}
+{{- include "mautrix-telegram.ensureDatabasePostgresPassword" . -}}
+{{- $payload := dict
+  "secretName" (include "mautrix-telegram.databasePostgresPasswordSecretName" .)
+  "secretKey" (include "mautrix-telegram.databasePostgresPasswordSecretKey" .)
+  "password" (include "mautrix-telegram.databasePostgresPassword" .)
+-}}
+{{- toYaml $payload | sha256sum -}}
 {{- end -}}
 
 {{- define "mautrix-telegram.databaseConnectionString" -}}

--- a/charts/mautrix-telegram/templates/postgres-secret.yaml
+++ b/charts/mautrix-telegram/templates/postgres-secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.postgres.enabled }}
+{{- $passwordCfg := (get (.Values.database.postgres | default dict) "password") | default dict -}}
+{{- if and .Values.postgres.enabled (eq ((get $passwordCfg "existingSecret") | default "") "") }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/mautrix-telegram/templates/postgres-statefulset.yaml
+++ b/charts/mautrix-telegram/templates/postgres-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         {{- include "mautrix-telegram.componentSelectorLabels" (dict "context" . "component" "postgres") | nindent 8 }}
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/postgres-secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include "mautrix-telegram.databasePostgresPasswordChecksum" . }}
     spec:
       {{- if .Values.postgres.podSecurityContext.enabled }}
       {{- $podSecurityContext := omit .Values.postgres.podSecurityContext "enabled" }}
@@ -44,8 +44,8 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mautrix-telegram.postgresFullname" . }}
-                  key: password
+                  name: {{ include "mautrix-telegram.databasePostgresPasswordSecretName" . }}
+                  key: {{ include "mautrix-telegram.databasePostgresPasswordSecretKey" . }}
           ports:
             - name: postgres
               containerPort: {{ .Values.postgres.service.port }}

--- a/charts/mautrix-telegram/values.external.example.yaml
+++ b/charts/mautrix-telegram/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_telegram
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_telegram
     sslMode: require

--- a/charts/mautrix-telegram/values.external.example.yaml
+++ b/charts/mautrix-telegram/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_telegram
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_telegram
     sslMode: require
 

--- a/charts/mautrix-telegram/values.schema.json
+++ b/charts/mautrix-telegram/values.schema.json
@@ -274,7 +274,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_telegram_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-telegram/values.schema.json
+++ b/charts/mautrix-telegram/values.schema.json
@@ -274,7 +274,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-telegram/values.secrets.yaml
+++ b/charts/mautrix-telegram/values.secrets.yaml
@@ -23,3 +23,10 @@ registration:
   managedSecret:
     enabled: false
   autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-telegram-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-telegram/values.yaml
+++ b/charts/mautrix-telegram/values.yaml
@@ -98,7 +98,8 @@ database:
     port: 5432
     user: mautrix_telegram
     password:
-      value: mautrix_telegram_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_telegram
     sslMode: disable
 

--- a/charts/mautrix-telegram/values.yaml
+++ b/charts/mautrix-telegram/values.yaml
@@ -100,6 +100,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_telegram
     sslMode: disable
 

--- a/charts/mautrix-twitter/Chart.lock
+++ b/charts/mautrix-twitter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:07.1794493Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.905714Z"

--- a/charts/mautrix-twitter/Chart.yaml
+++ b/charts/mautrix-twitter/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/twitter/
 sources:
   - https://github.com/mautrix/twitter
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_twitter
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_twitter
     sslMode: require
 ```

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_twitter
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_twitter
     sslMode: require

--- a/charts/mautrix-twitter/values.external.example.yaml
+++ b/charts/mautrix-twitter/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_twitter
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_twitter
     sslMode: require
 

--- a/charts/mautrix-twitter/values.external.example.yaml
+++ b/charts/mautrix-twitter/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_twitter
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_twitter
     sslMode: require

--- a/charts/mautrix-twitter/values.schema.json
+++ b/charts/mautrix-twitter/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-twitter/values.schema.json
+++ b/charts/mautrix-twitter/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_twitter_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-twitter/values.secrets.yaml
+++ b/charts/mautrix-twitter/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-twitter-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-twitter/values.yaml
+++ b/charts/mautrix-twitter/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_twitter
     sslMode: disable
 

--- a/charts/mautrix-twitter/values.yaml
+++ b/charts/mautrix-twitter/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_twitter
     password:
-      value: mautrix_twitter_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_twitter
     sslMode: disable
 

--- a/charts/mautrix-whatsapp/Chart.lock
+++ b/charts/mautrix-whatsapp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:07.3854006Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.906196Z"

--- a/charts/mautrix-whatsapp/Chart.yaml
+++ b/charts/mautrix-whatsapp/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/whatsapp/
 sources:
   - https://github.com/mautrix/whatsapp
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_whatsapp
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_whatsapp
     sslMode: require
 ```

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_whatsapp
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_whatsapp
     sslMode: require

--- a/charts/mautrix-whatsapp/values.external.example.yaml
+++ b/charts/mautrix-whatsapp/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_whatsapp
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_whatsapp
     sslMode: require
 

--- a/charts/mautrix-whatsapp/values.external.example.yaml
+++ b/charts/mautrix-whatsapp/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_whatsapp
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_whatsapp
     sslMode: require

--- a/charts/mautrix-whatsapp/values.schema.json
+++ b/charts/mautrix-whatsapp/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-whatsapp/values.schema.json
+++ b/charts/mautrix-whatsapp/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_whatsapp_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-whatsapp/values.secrets.yaml
+++ b/charts/mautrix-whatsapp/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-whatsapp-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-whatsapp/values.yaml
+++ b/charts/mautrix-whatsapp/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_whatsapp
     sslMode: disable
 

--- a/charts/mautrix-whatsapp/values.yaml
+++ b/charts/mautrix-whatsapp/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_whatsapp
     password:
-      value: mautrix_whatsapp_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_whatsapp
     sslMode: disable
 

--- a/charts/mautrix-zulip/Chart.lock
+++ b/charts/mautrix-zulip/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mautrix-go-base
   repository: file://../mautrix-go-base
-  version: 1.0.0
-digest: sha256:0032143722dbaf9e76001f993eebe693c48b763a45b6a1f52e501f085f8450e0
-generated: "2026-03-13T10:06:07.5915573Z"
+  version: 1.0.1
+digest: sha256:795c471f803318ac1bed5179e2dbc3bbf0ae27aeca9899571e31117241a73b6e
+generated: "2026-03-13T19:46:29.906439Z"

--- a/charts/mautrix-zulip/Chart.yaml
+++ b/charts/mautrix-zulip/Chart.yaml
@@ -5,9 +5,9 @@ home: https://docs.mau.fi/bridges/go/zulip/
 sources:
   - https://github.com/mautrix/zulip
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base
-    version: 1.0.0
+    version: 1.0.1
     repository: file://../mautrix-go-base

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -212,6 +212,8 @@ logging:
 
 Bundled Postgres is enabled by default.
 
+If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
 Disable bundled Postgres and use external DB:
 
 ```yaml

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -212,7 +212,9 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from the chart-managed Postgres Secret when present; otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+
+`database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
 
 Disable bundled Postgres and use external DB:
 
@@ -227,6 +229,8 @@ database:
     user: mautrix_zulip
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_zulip
     sslMode: require
 ```

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -229,7 +229,8 @@ database:
     user: mautrix_zulip
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_zulip
     sslMode: require

--- a/charts/mautrix-zulip/values.external.example.yaml
+++ b/charts/mautrix-zulip/values.external.example.yaml
@@ -15,6 +15,8 @@ database:
     user: mautrix_zulip
     password:
       value: replace_me
+      # existingSecret: my-postgres-password
+      # existingSecretKey: password
     database: mautrix_zulip
     sslMode: require
 

--- a/charts/mautrix-zulip/values.external.example.yaml
+++ b/charts/mautrix-zulip/values.external.example.yaml
@@ -15,7 +15,8 @@ database:
     user: mautrix_zulip
     password:
       value: replace_me
-      # existingSecret: my-postgres-password
+      # Remove `value` and replace with the below to use an external secret
+			# existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_zulip
     sslMode: require

--- a/charts/mautrix-zulip/values.schema.json
+++ b/charts/mautrix-zulip/values.schema.json
@@ -402,7 +402,17 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
+                  "description": "Inline Postgres password. Mutually exclusive with existingSecret. If empty and existingSecret is unset, sourced from the chart-managed Secret when present or auto-generated when postgres.enabled=true. Required, or provide existingSecret, when postgres.enabled=false."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "default": "password",
+                  "description": "Key in existingSecret containing the Postgres password."
                 }
               }
             },

--- a/charts/mautrix-zulip/values.schema.json
+++ b/charts/mautrix-zulip/values.schema.json
@@ -402,7 +402,7 @@
               "properties": {
                 "value": {
                   "type": "string",
-                  "default": "mautrix_zulip_password"
+                  "description": "If empty and postgres.enabled=true, sourced from the chart-managed Secret when present; otherwise auto-generated. Required when postgres.enabled=false."
                 }
               }
             },

--- a/charts/mautrix-zulip/values.secrets.yaml
+++ b/charts/mautrix-zulip/values.secrets.yaml
@@ -26,3 +26,10 @@ registration:
 #     managedSecret:
 #       enabled: false
 #     autoGenerate: false
+
+# Optional: source the Postgres password from an external Secret.
+# database:
+#   postgres:
+#     password:
+#       existingSecret: mautrix-zulip-postgres-password
+#       existingSecretKey: password

--- a/charts/mautrix-zulip/values.yaml
+++ b/charts/mautrix-zulip/values.yaml
@@ -129,6 +129,10 @@ database:
     password:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
+      # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      existingSecret: ""
+      # Key in existingSecret containing the Postgres password.
+      existingSecretKey: password
     database: mautrix_zulip
     sslMode: disable
 

--- a/charts/mautrix-zulip/values.yaml
+++ b/charts/mautrix-zulip/values.yaml
@@ -127,7 +127,8 @@ database:
     port: 5432
     user: mautrix_zulip
     password:
-      value: mautrix_zulip_password
+      # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
+      value: ""
     database: mautrix_zulip
     sslMode: disable
 


### PR DESCRIPTION
Initially create to resolve [#18] request to allow using existing Kubernetes Secrets for Postgres password but scope expanded to also generate managed Postgres db passwords instead of using hardcoded values per chart. Charts now support the below, this works for both bundled Postgres and external Postgres:

```yaml
database:
  postgres:
    password:
      value: ""
      existingSecret: my-postgres-password
      existingSecretKey: password
```

Postgres passwords can now come from:

1. `database.postgres.password.value`
2. `database.postgres.password.existingSecret` + `existingSecretKey`
3. The existing chart-managed bundled Postgres Secret
4. A newly auto-generated password for bundled Postgres on first install

`value` and `existingSecret` are mutually exclusive - providing both will cause the chart to fail fast.

All affected charts now include:
- Updated `values.yaml`
- Updated `values.schema.json`
- README updates covering password resolution behavior
- `values.external.example.yaml` examples with commented `existingSecret` / `existingSecretKey`
- `values.secrets.yaml` examples for Secret-based Postgres passwords