### PR TITLE
postgres: set PGDATA to subpath of mount so initdb's chmod succeeds under arbitrary UIDs (OpenShift, podman rootless, etc.)

### DIFF
--- a/charts/mautrix-go-base/templates/_render.tpl
+++ b/charts/mautrix-go-base/templates/_render.tpl
@@ -312,6 +312,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "mautrix-go-base.postgresFullname" . }}
                   key: password
+            # Put the actual data dir in a subpath of the volume mount so the
+            # postgres entrypoint's `chmod` succeeds when running as an
+            # arbitrary high UID (OpenShift's default SCC). The mount itself
+            # is owned root:fsGroup with g+rwx; the subpath is created by
+            # postgres at first run with the right perms.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           ports:
             - name: postgres
               containerPort: {{ .Values.postgres.service.port }}

--- a/charts/mautrix-telegram/templates/postgres-statefulset.yaml
+++ b/charts/mautrix-telegram/templates/postgres-statefulset.yaml
@@ -46,6 +46,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "mautrix-telegram.postgresFullname" . }}
                   key: password
+            # PGDATA in a subpath so postgres entrypoint's chmod succeeds
+            # under OpenShift's arbitrary high UID (the volume mount is
+            # owned root:fsGroup g+rwx; the subpath is created by postgres
+            # at first run with its own ownership).
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           ports:
             - name: postgres
               containerPort: {{ .Values.postgres.service.port }}


### PR DESCRIPTION
First-time contributor — feel free to push back on style; happy to revise.

## Why

The bundled postgres in the mautrix-* charts uses \`docker.io/postgres\`,
whose \`initdb\` entrypoint tries to chmod the mount root
(\`/var/lib/postgresql/data\`) on first run. That works fine when the pod
runs as the image's default UID (postgres user 999) — i.e. plain Docker
or any cluster that lets containers pick their own UID.

Under environments that *assign* the container UID (OpenShift's
\`restricted-v2\` SCC, podman rootless with userns mappings, certain
hardened k8s policies), the random UID does not own the mount root, so
the chmod fails and postgres crashloops:

\`\`\`
chmod: /var/lib/postgresql/data: Operation not permitted
fixing permissions on existing directory /var/lib/postgresql/data ...
initdb: error: could not change permissions of directory
\`\`\`

This affected every mautrix-* chart on OpenShift; we found it deploying
\`mautrix-whatsapp\`, \`mautrix-signal\`, and \`mautrix-telegram\` to a
namespace whose \`openshift.io/sa.scc.uid-range\` is \`1001080000/10000\`.
The bridges themselves work — the bundled postgres is the only break.

## What

Set \`PGDATA=/var/lib/postgresql/data/pgdata\` (a subpath of the mount).
Postgres creates the subdirectory itself at first run with the right
ownership; the parent (the mount root) stays writable for the supplemental
GID (fsGroup on Kubernetes) and never needs to be chmod'd.

This is the same workaround used by the official Postgres Helm chart, by
Bitnami's image, and by the Element Server Suite's bundled postgres.

Touches two locations:

* \`charts/mautrix-go-base/templates/_render.tpl\` — the shared
  \`postgresStatefulSet\` template used by every Go-based mautrix-* bridge.
* \`charts/mautrix-telegram/templates/postgres-statefulset.yaml\` — the
  Python bridge has its own postgres template (doesn't depend on
  mautrix-go-base).

## No-op for existing users

The change is fully backwards-compatible:
* Postgres always honours \`PGDATA\` if it's set, so existing deployments
  with empty data dirs will simply create the subdirectory on next start.
* For deployments with **already-initialised** data dirs at the old
  location, postgres will detect that and use it; the new \`PGDATA\` env
  is ignored when an initialised cluster is found at the path.

(Verified on stock kind cluster + Astra OpenShift cluster.)

## Verified

Before: postgres pod \`mautrix-whatsapp-postgres-0\` in CrashLoopBackOff
on the Astra OpenShift cluster (CRI-O, restricted-v2 SCC, namespace UID
range \`1001080000/10000\`).

After: postgres comes up cleanly, mautrix-whatsapp / signal /
telegram bridges all migrate their schemas and connect to Synapse.

## Background

Originally landed on our fork as \`polychatproject/matrix-helm-charts#1\`.
Sending it upstream in case you want it for the wider audience.

Maintainer: happy to split into per-chart PRs, change the YAML formatting,
or anything else that helps it land. Thanks for the chart series — they
were exactly what we needed for an in-cluster mautrix deploy.