### PR TITLE
Fix/existing secret gitops

### DIFF
--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-bluesky-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-bluesky \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-bluesky-registration
+      secretKey: appservice-registration-bluesky.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-bluesky/README.md
+++ b/charts/mautrix-bluesky/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer). Note: this chart currently defaults to `v0.2510.0`, which predates env config support; override `image.tag` with a `v0.2512.0`-or-newer release when using `existingSecret`.
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_bluesky
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_bluesky
     sslMode: require

--- a/charts/mautrix-bluesky/values.external.example.yaml
+++ b/charts/mautrix-bluesky/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_bluesky
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_bluesky
     sslMode: require

--- a/charts/mautrix-bluesky/values.schema.json
+++ b/charts/mautrix-bluesky/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-bluesky/values.schema.json
+++ b/charts/mautrix-bluesky/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-bluesky/values.secrets.yaml
+++ b/charts/mautrix-bluesky/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-bluesky/values.secrets.yaml
+++ b/charts/mautrix-bluesky/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-bluesky.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-bluesky-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-bluesky-runtime-secrets
   managedSecret:

--- a/charts/mautrix-bluesky/values.yaml
+++ b/charts/mautrix-bluesky/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-bluesky/values.yaml
+++ b/charts/mautrix-bluesky/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer).
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_gmessages
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gmessages
     sslMode: require

--- a/charts/mautrix-gmessages/README.md
+++ b/charts/mautrix-gmessages/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-gmessages-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-gmessages \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-gmessages-registration
+      secretKey: appservice-registration-gmessages.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-gmessages/values.external.example.yaml
+++ b/charts/mautrix-gmessages/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_gmessages
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gmessages
     sslMode: require

--- a/charts/mautrix-gmessages/values.schema.json
+++ b/charts/mautrix-gmessages/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-gmessages/values.schema.json
+++ b/charts/mautrix-gmessages/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-gmessages/values.secrets.yaml
+++ b/charts/mautrix-gmessages/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-gmessages/values.secrets.yaml
+++ b/charts/mautrix-gmessages/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-gmessages.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-gmessages-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-gmessages-runtime-secrets
   managedSecret:

--- a/charts/mautrix-gmessages/values.yaml
+++ b/charts/mautrix-gmessages/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-gmessages/values.yaml
+++ b/charts/mautrix-gmessages/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-go-base/README.md
+++ b/charts/mautrix-go-base/README.md
@@ -40,7 +40,18 @@ A wrapper chart that depends on this library must define these helpers:
 5. Fail on overlaps with wrapper-declared reserved paths.
 6. Inject managed bridge logging as stdout `pretty-colored` with `min_level` from top-level `values.logging` (default `info`).
 7. Inject managed local double puppet secret at `double_puppet.secrets[homeserver.domain]`.
-8. Merge as: `baseExtra` + `{network: networkExtra}` + `managedConfig` + managed logging + managed double puppet (managed wins).
+8. Merge as: `baseExtra` + `{network: networkExtra}` + `managedConfig` + managed logging + managed double puppet + managed env config prefix (managed wins).
+
+## Runtime Postgres password injection
+
+When `database.postgres.password.existingSecret` is set, the library never reads the Secret at template time (no `lookup`), so rendering works offline (plain `helm template`, ArgoCD/Flux repo-side rendering):
+
+- `mautrix-go-base.databaseConnectionString` renders the URI with a literal `$(MAUTRIX_HELM_DATABASE_PASSWORD)` placeholder instead of the password.
+- The bridge StatefulSet defines `MAUTRIX_HELM_DATABASE_PASSWORD` via `secretKeyRef` and `MAUTRIX_HELM_CONFIG_DATABASE__URI` with the placeholder URI; the kubelet expands the `$(VAR)` reference at container start.
+- `mautrix-go-base.bridgev2MergedConfig` injects `env_config_prefix: MAUTRIX_HELM_CONFIG_`, so mautrix-go (v0.26.1+, bridge releases `v0.2512.0`+) overrides `database.uri` from that env var at startup.
+- `mautrix-go-base.databasePostgresPasswordChecksum` hashes only the Secret name/key in this mode, never the value; rotation therefore needs an external reloader.
+
+`values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set. The password must be URI-safe because the runtime substitution cannot URL-encode it.
 
 ## Kubernetes Behavior
 

--- a/charts/mautrix-go-base/README.md
+++ b/charts/mautrix-go-base/README.md
@@ -42,16 +42,26 @@ A wrapper chart that depends on this library must define these helpers:
 7. Inject managed local double puppet secret at `double_puppet.secrets[homeserver.domain]`.
 8. Merge as: `baseExtra` + `{network: networkExtra}` + `managedConfig` + managed logging + managed double puppet + managed env config prefix (managed wins).
 
-## Runtime Postgres password injection
+## Runtime secret injection (GitOps-safe existingSecret)
 
-When `database.postgres.password.existingSecret` is set, the library never reads the Secret at template time (no `lookup`), so rendering works offline (plain `helm template`, ArgoCD/Flux repo-side rendering):
+Secrets referenced via `existingSecret` are never read at template time (no `lookup`), so rendering works offline (plain `helm template`, ArgoCD/Flux repo-side rendering). Both mechanisms rely on mautrix-go's `env_config_prefix` support (v0.26.1+, bridge releases `v0.2512.0`+) and inject `env_config_prefix: MAUTRIX_HELM_CONFIG_` into the merged config.
+
+### Registration tokens (`registration.existingSecret`)
+
+When `registration.existingSecret` is set (keys `asToken`, `hsToken`):
+
+- `ensureRuntimeSecrets` performs no `lookup`; the computed values are literal `$(MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN)`/`...HS_TOKEN` placeholders that end up in the rendered config file.
+- The bridge StatefulSet defines those two env vars via `secretKeyRef`, and the bridge overrides `appservice.as_token`/`hs_token` from them at startup.
+- Inline `registration.asToken`/`hsToken` are rejected (mutually exclusive).
+- The registration ConfigMaps (primary and Synapse copy) are **not rendered** — the tokens are unknown at template time, so the registration file must be provided to the homeserver from the same secret source.
+
+### Postgres password (`database.postgres.password.existingSecret`)
 
 - `mautrix-go-base.databaseConnectionString` renders the URI with a literal `$(MAUTRIX_HELM_DATABASE_PASSWORD)` placeholder instead of the password.
-- The bridge StatefulSet defines `MAUTRIX_HELM_DATABASE_PASSWORD` via `secretKeyRef` and `MAUTRIX_HELM_CONFIG_DATABASE__URI` with the placeholder URI; the kubelet expands the `$(VAR)` reference at container start.
-- `mautrix-go-base.bridgev2MergedConfig` injects `env_config_prefix: MAUTRIX_HELM_CONFIG_`, so mautrix-go (v0.26.1+, bridge releases `v0.2512.0`+) overrides `database.uri` from that env var at startup.
+- The bridge StatefulSet defines `MAUTRIX_HELM_DATABASE_PASSWORD` via `secretKeyRef` and `MAUTRIX_HELM_CONFIG_DATABASE__URI` with the placeholder URI; the kubelet expands the `$(VAR)` reference at container start, and the bridge overrides `database.uri` from that env var at startup.
 - `mautrix-go-base.databasePostgresPasswordChecksum` hashes only the Secret name/key in this mode, never the value; rotation therefore needs an external reloader.
 
-`values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set. The password must be URI-safe because the runtime substitution cannot URL-encode it.
+`values.config.baseExtra` cannot set `env_config_prefix` while either `existingSecret` is set. The database password must be URI-safe because the runtime substitution cannot URL-encode it.
 
 ## Kubernetes Behavior
 

--- a/charts/mautrix-go-base/templates/_helpers.tpl
+++ b/charts/mautrix-go-base/templates/_helpers.tpl
@@ -720,15 +720,31 @@ false
 {{- end -}}
 
 {{- $managedEnvConfig := dict -}}
-{{- if eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true" -}}
+{{- if or (eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true") (eq (include "mautrix-go-base.registrationUseExistingSecret" .) "true") -}}
 {{- if hasKey $baseExtra "env_config_prefix" -}}
-{{- fail (printf "values.config.baseExtra cannot set env_config_prefix when database.postgres.password.existingSecret is set; the chart manages it (%s) to inject the database password at runtime" (include "mautrix-go-base.envConfigPrefix" .)) -}}
+{{- fail (printf "values.config.baseExtra cannot set env_config_prefix when database.postgres.password.existingSecret or registration.existingSecret is set; the chart manages it (%s) to inject secrets at runtime" (include "mautrix-go-base.envConfigPrefix" .)) -}}
 {{- end -}}
 {{- $managedEnvConfig = dict "env_config_prefix" (include "mautrix-go-base.envConfigPrefix" .) -}}
 {{- end -}}
 
 {{- $merged := mustMergeOverwrite (dict) $baseExtra $networkBlock $managed $managedLogging $managedDoublePuppet $managedEnvConfig -}}
 {{ toYaml $merged }}
+{{- end -}}
+
+{{- define "mautrix-go-base.registrationUseExistingSecret" -}}
+{{- if ne (.Values.registration.existingSecret | default "") "" -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/* Maps a runtime secret key to the env config suffix that overrides the
+     matching bridge config path at startup (e.g. asToken -> appservice.as_token). */}}
+{{- define "mautrix-go-base.runtimeSecretEnvKey" -}}
+{{- if eq .key "asToken" -}}
+APPSERVICE__AS_TOKEN
+{{- else if eq .key "hsToken" -}}
+APPSERVICE__HS_TOKEN
+{{- else -}}
+{{- fail (printf "no env config mapping defined for runtime secret key %q" .key) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mautrix-go-base.ensureRuntimeSecrets" -}}
@@ -738,11 +754,16 @@ false
 {{- fail (printf "%s.runtimeSecretKeys must render a comma-separated list of registration key names" .Chart.Name) -}}
 {{- end -}}
 {{- $keys := splitList "," $keysRaw -}}
-{{- $useExistingSecret := ne (.Values.registration.existingSecret | default "") "" -}}
+{{- $useExistingSecret := eq (include "mautrix-go-base.registrationUseExistingSecret" .) "true" -}}
 {{- $managedSecret := .Values.registration.managedSecret | default dict -}}
 {{- $managedSecretEnabled := and (not $useExistingSecret) ((get $managedSecret "enabled") | default false) -}}
 {{- $secretName := include "mautrix-go-base.runtimeSecretName" . -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{/* Never lookup when existingSecret is set: the Secret is only referenced at
+     runtime via secretKeyRef so rendering stays offline/GitOps-safe. */}}
+{{- $existing := dict -}}
+{{- if not $useExistingSecret -}}
+{{- $existing = lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- end -}}
 {{- $computed := dict -}}
 {{- range $idx, $key := $keys -}}
 {{- $secretKey := $key | trim -}}
@@ -753,6 +774,12 @@ false
 {{- if eq $value "generate" -}}
 {{- fail (printf "values.registration.%s must not be set to 'generate'; leave empty for auto-generation" $secretKey) -}}
 {{- end -}}
+{{- if $useExistingSecret -}}
+{{- if ne $value "" -}}
+{{- fail (printf "values.registration.%s and values.registration.existingSecret are mutually exclusive; the value is read from the Secret at runtime" $secretKey) -}}
+{{- end -}}
+{{- $value = printf "$(%s%s)" (include "mautrix-go-base.envConfigPrefix" $) (include "mautrix-go-base.runtimeSecretEnvKey" (dict "key" $secretKey)) -}}
+{{- else -}}
 {{- if and (eq $value "") $existing (hasKey $existing.data $secretKey) -}}
 {{- $value = (index $existing.data $secretKey | b64dec) -}}
 {{- end -}}
@@ -761,6 +788,7 @@ false
 {{- $value = (randAlphaNum 64 | sha256sum) -}}
 {{- else -}}
 {{- fail (printf "registration.%s is required when missing from secret %q (set registration.%s, set registration.existingSecret to a populated Secret, or enable registration.autoGenerate with registration.managedSecret.enabled=true)" $secretKey $secretName $secretKey) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $_ := set $computed $secretKey $value -}}

--- a/charts/mautrix-go-base/templates/_helpers.tpl
+++ b/charts/mautrix-go-base/templates/_helpers.tpl
@@ -104,6 +104,25 @@ app.kubernetes.io/component: {{ .component }}
 password
 {{- end -}}
 
+{{- define "mautrix-go-base.databasePostgresUseExistingSecret" -}}
+{{- $postgres := .Values.database.postgres | default dict -}}
+{{- $passwordCfg := (get $postgres "password") | default dict -}}
+{{- $password := (get $passwordCfg "value") | default "" -}}
+{{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
+{{- if and (ne $password "") (ne $existingSecretName "") -}}
+{{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if ne $existingSecretName "" -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "mautrix-go-base.databasePasswordEnvVarName" -}}
+MAUTRIX_HELM_DATABASE_PASSWORD
+{{- end -}}
+
+{{- define "mautrix-go-base.envConfigPrefix" -}}
+MAUTRIX_HELM_CONFIG_
+{{- end -}}
+
 {{- define "mautrix-go-base.databasePostgresPasswordSecretName" -}}
 {{- $postgres := .Values.database.postgres | default dict -}}
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
@@ -152,19 +171,13 @@ password
 {{- $passwordCfg := (get $postgres "password") | default dict -}}
 {{- $password := (get $passwordCfg "value") | default "" -}}
 {{- $existingSecretName := (get $passwordCfg "existingSecret") | default "" -}}
-{{- $existingSecretKey := (get $passwordCfg "existingSecretKey") | default "password" -}}
 {{- if and (ne $password "") (ne $existingSecretName "") -}}
 {{- fail "values.database.postgres.password.value and values.database.postgres.password.existingSecret are mutually exclusive" -}}
 {{- end -}}
 {{- if ne $password "" -}}
 {{- $password -}}
 {{- else if ne $existingSecretName "" -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $existingSecretName -}}
-{{- if and $existing (hasKey $existing "data") (hasKey $existing.data $existingSecretKey) -}}
-{{- index $existing.data $existingSecretKey | b64dec -}}
-{{- else -}}
-{{- fail (printf "values.database.postgres.password.existingSecret %q must contain key %q in namespace %q" $existingSecretName $existingSecretKey .Release.Namespace) -}}
-{{- end -}}
+{{- fail (printf "internal error: the Postgres password from existingSecret %q is resolved at runtime via secretKeyRef and must not be resolved at template time" $existingSecretName) -}}
 {{- else -}}
 {{- include "mautrix-go-base.ensureDatabasePostgresPassword" . -}}
 {{- index .Values.database.postgres "_computedPassword" -}}
@@ -172,6 +185,15 @@ password
 {{- end -}}
 
 {{- define "mautrix-go-base.databasePostgresPasswordChecksum" -}}
+{{- if eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true" -}}
+{{/* Never embed the secret value: it is not readable at template time (GitOps-safe).
+     Rotating the referenced Secret in place does not restart pods; use a reloader. */}}
+{{- $payload := dict
+  "secretName" (include "mautrix-go-base.databasePostgresPasswordSecretName" .)
+  "secretKey" (include "mautrix-go-base.databasePostgresPasswordSecretKey" .)
+-}}
+{{- toYaml $payload | sha256sum -}}
+{{- else -}}
 {{- include "mautrix-go-base.ensureDatabasePostgresPassword" . -}}
 {{- $payload := dict
   "secretName" (include "mautrix-go-base.databasePostgresPasswordSecretName" .)
@@ -179,6 +201,7 @@ password
   "password" (include "mautrix-go-base.databasePostgresPassword" .)
 -}}
 {{- toYaml $payload | sha256sum -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mautrix-go-base.databaseConnectionString" -}}
@@ -194,9 +217,18 @@ password
 {{- end -}}
 {{- $database := include "mautrix-go-base.databasePostgresDatabase" . -}}
 {{- $user := include "mautrix-go-base.databasePostgresUser" . -}}
-{{- $password := include "mautrix-go-base.databasePostgresPassword" . -}}
+{{- $passwordSegment := "" -}}
+{{- if eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true" -}}
+{{/* The real password is injected at runtime: the kubelet expands this $(VAR)
+     reference in the MAUTRIX_HELM_CONFIG_DATABASE__URI env var, and the bridge's
+     env_config_prefix support overrides database.uri from that env var. The
+     placeholder is intentionally left unexpanded in the config file itself. */}}
+{{- $passwordSegment = printf "$(%s)" (include "mautrix-go-base.databasePasswordEnvVarName" .) -}}
+{{- else -}}
+{{- $passwordSegment = include "mautrix-go-base.databasePostgresPassword" . | urlquery -}}
+{{- end -}}
 {{- $sslMode := (get $postgres "sslMode") | default "" -}}
-{{- $connectionString := printf "postgres://%s:%s@%s:%v/%s" ($user | urlquery) ($password | urlquery) $host $port ($database | urlquery) -}}
+{{- $connectionString := printf "postgres://%s:%s@%s:%v/%s" ($user | urlquery) $passwordSegment $host $port ($database | urlquery) -}}
 {{- if ne $sslMode "" -}}
 {{- printf "%s?sslmode=%s" $connectionString ($sslMode | urlquery) -}}
 {{- else -}}
@@ -687,7 +719,15 @@ false
 {{- $networkBlock = dict "network" $networkExtra -}}
 {{- end -}}
 
-{{- $merged := mustMergeOverwrite (dict) $baseExtra $networkBlock $managed $managedLogging $managedDoublePuppet -}}
+{{- $managedEnvConfig := dict -}}
+{{- if eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true" -}}
+{{- if hasKey $baseExtra "env_config_prefix" -}}
+{{- fail (printf "values.config.baseExtra cannot set env_config_prefix when database.postgres.password.existingSecret is set; the chart manages it (%s) to inject the database password at runtime" (include "mautrix-go-base.envConfigPrefix" .)) -}}
+{{- end -}}
+{{- $managedEnvConfig = dict "env_config_prefix" (include "mautrix-go-base.envConfigPrefix" .) -}}
+{{- end -}}
+
+{{- $merged := mustMergeOverwrite (dict) $baseExtra $networkBlock $managed $managedLogging $managedDoublePuppet $managedEnvConfig -}}
 {{ toYaml $merged }}
 {{- end -}}
 

--- a/charts/mautrix-go-base/templates/_render.tpl
+++ b/charts/mautrix-go-base/templates/_render.tpl
@@ -56,6 +56,17 @@ spec:
             {{- include (printf "%s.bridgeCommand" .Chart.Name) . | nindent 12 }}
           args:
             {{- include (printf "%s.bridgeArgs" .Chart.Name) . | nindent 12 }}
+          {{- if eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true" }}
+          env:
+            {{- /* Order matters: the kubelet only expands $(VAR) references to env vars defined earlier in this list. */}}
+            - name: {{ include "mautrix-go-base.databasePasswordEnvVarName" . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mautrix-go-base.databasePostgresPasswordSecretName" . }}
+                  key: {{ include "mautrix-go-base.databasePostgresPasswordSecretKey" . }}
+            - name: {{ include "mautrix-go-base.envConfigPrefix" . }}DATABASE__URI
+              value: {{ include "mautrix-go-base.databaseConnectionString" . | quote }}
+          {{- end }}
           ports:
             - name: appservice
               containerPort: {{ .Values.appservice.port }}

--- a/charts/mautrix-go-base/templates/_render.tpl
+++ b/charts/mautrix-go-base/templates/_render.tpl
@@ -56,8 +56,23 @@ spec:
             {{- include (printf "%s.bridgeCommand" .Chart.Name) . | nindent 12 }}
           args:
             {{- include (printf "%s.bridgeArgs" .Chart.Name) . | nindent 12 }}
-          {{- if eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true" }}
+          {{- $dbExistingSecret := eq (include "mautrix-go-base.databasePostgresUseExistingSecret" .) "true" }}
+          {{- $registrationExistingSecret := eq (include "mautrix-go-base.registrationUseExistingSecret" .) "true" }}
+          {{- if or $dbExistingSecret $registrationExistingSecret }}
           env:
+            {{- if $registrationExistingSecret }}
+            - name: {{ include "mautrix-go-base.envConfigPrefix" . }}{{ include "mautrix-go-base.runtimeSecretEnvKey" (dict "key" "asToken") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mautrix-go-base.runtimeSecretName" . }}
+                  key: asToken
+            - name: {{ include "mautrix-go-base.envConfigPrefix" . }}{{ include "mautrix-go-base.runtimeSecretEnvKey" (dict "key" "hsToken") }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mautrix-go-base.runtimeSecretName" . }}
+                  key: hsToken
+            {{- end }}
+            {{- if $dbExistingSecret }}
             {{- /* Order matters: the kubelet only expands $(VAR) references to env vars defined earlier in this list. */}}
             - name: {{ include "mautrix-go-base.databasePasswordEnvVarName" . }}
               valueFrom:
@@ -66,6 +81,7 @@ spec:
                   key: {{ include "mautrix-go-base.databasePostgresPasswordSecretKey" . }}
             - name: {{ include "mautrix-go-base.envConfigPrefix" . }}DATABASE__URI
               value: {{ include "mautrix-go-base.databaseConnectionString" . | quote }}
+            {{- end }}
           {{- end }}
           ports:
             - name: appservice
@@ -185,6 +201,11 @@ stringData:
 {{- end -}}
 
 {{- define "mautrix-go-base.registrationConfigMap" -}}
+{{/* When registration.existingSecret is set the tokens are only known at
+     runtime, so a chart-rendered registration file would be unusable; the
+     registration must be provided to the homeserver from the same secret
+     source instead (see README). */}}
+{{- if eq (include "mautrix-go-base.registrationUseExistingSecret" .) "false" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -194,11 +215,12 @@ metadata:
 data:
   {{ include (printf "%s.registrationFileKey" .Chart.Name) . }}: |
 {{ include (printf "%s.registrationConfig" .Chart.Name) . | indent 4 }}
+{{- end }}
 {{- end -}}
 
 {{- define "mautrix-go-base.synapseRegistrationConfigMap" -}}
 {{- $synapseNamespace := .Values.registration.synapseNamespace | default "" | trim -}}
-{{- if and $synapseNamespace (ne $synapseNamespace .Release.Namespace) }}
+{{- if and $synapseNamespace (ne $synapseNamespace .Release.Namespace) (eq (include "mautrix-go-base.registrationUseExistingSecret" .) "false") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer). Note: this chart currently defaults to `v0.2511.0`, which predates env config support; override `image.tag` with a `v0.2512.0`-or-newer release when using `existingSecret`.
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_gvoice
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gvoice
     sslMode: require

--- a/charts/mautrix-gvoice/README.md
+++ b/charts/mautrix-gvoice/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-gvoice-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-gvoice \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-gvoice-registration
+      secretKey: appservice-registration-gvoice.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-gvoice/values.external.example.yaml
+++ b/charts/mautrix-gvoice/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_gvoice
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_gvoice
     sslMode: require

--- a/charts/mautrix-gvoice/values.schema.json
+++ b/charts/mautrix-gvoice/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-gvoice/values.schema.json
+++ b/charts/mautrix-gvoice/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-gvoice/values.secrets.yaml
+++ b/charts/mautrix-gvoice/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-gvoice/values.secrets.yaml
+++ b/charts/mautrix-gvoice/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-gvoice.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-gvoice-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-gvoice-runtime-secrets
   managedSecret:

--- a/charts/mautrix-gvoice/values.yaml
+++ b/charts/mautrix-gvoice/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-gvoice/values.yaml
+++ b/charts/mautrix-gvoice/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-linkedin-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-linkedin \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-linkedin-registration
+      secretKey: appservice-registration-linkedin.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-linkedin/README.md
+++ b/charts/mautrix-linkedin/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer).
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_linkedin
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_linkedin
     sslMode: require

--- a/charts/mautrix-linkedin/values.external.example.yaml
+++ b/charts/mautrix-linkedin/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_linkedin
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_linkedin
     sslMode: require

--- a/charts/mautrix-linkedin/values.schema.json
+++ b/charts/mautrix-linkedin/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-linkedin/values.schema.json
+++ b/charts/mautrix-linkedin/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-linkedin/values.secrets.yaml
+++ b/charts/mautrix-linkedin/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-linkedin.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-linkedin-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-linkedin-runtime-secrets
   managedSecret:

--- a/charts/mautrix-linkedin/values.secrets.yaml
+++ b/charts/mautrix-linkedin/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-linkedin/values.yaml
+++ b/charts/mautrix-linkedin/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-linkedin/values.yaml
+++ b/charts/mautrix-linkedin/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer).
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_meta
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_meta
     sslMode: require

--- a/charts/mautrix-meta/README.md
+++ b/charts/mautrix-meta/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-meta-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-meta \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-meta-registration
+      secretKey: appservice-registration-meta.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-meta/values.external.example.yaml
+++ b/charts/mautrix-meta/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_meta
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_meta
     sslMode: require

--- a/charts/mautrix-meta/values.schema.json
+++ b/charts/mautrix-meta/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-meta/values.schema.json
+++ b/charts/mautrix-meta/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-meta/values.secrets.yaml
+++ b/charts/mautrix-meta/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-meta.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-meta-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-meta-runtime-secrets
   managedSecret:

--- a/charts/mautrix-meta/values.secrets.yaml
+++ b/charts/mautrix-meta/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-meta/values.yaml
+++ b/charts/mautrix-meta/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-meta/values.yaml
+++ b/charts/mautrix-meta/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer).
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_signal
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_signal
     sslMode: require

--- a/charts/mautrix-signal/README.md
+++ b/charts/mautrix-signal/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-signal-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-signal \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-signal-registration
+      secretKey: appservice-registration-signal.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-signal/values.external.example.yaml
+++ b/charts/mautrix-signal/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_signal
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_signal
     sslMode: require

--- a/charts/mautrix-signal/values.schema.json
+++ b/charts/mautrix-signal/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-signal/values.schema.json
+++ b/charts/mautrix-signal/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-signal/values.secrets.yaml
+++ b/charts/mautrix-signal/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-signal.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-signal-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-signal-runtime-secrets
   managedSecret:

--- a/charts/mautrix-signal/values.secrets.yaml
+++ b/charts/mautrix-signal/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-signal/values.yaml
+++ b/charts/mautrix-signal/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-signal/values.yaml
+++ b/charts/mautrix-signal/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer).
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_slack
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_slack
     sslMode: require

--- a/charts/mautrix-slack/README.md
+++ b/charts/mautrix-slack/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-slack-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-slack \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-slack-registration
+      secretKey: appservice-registration-slack.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-slack/values.external.example.yaml
+++ b/charts/mautrix-slack/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_slack
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_slack
     sslMode: require

--- a/charts/mautrix-slack/values.schema.json
+++ b/charts/mautrix-slack/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-slack/values.schema.json
+++ b/charts/mautrix-slack/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-slack/values.secrets.yaml
+++ b/charts/mautrix-slack/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-slack.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-slack-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-slack-runtime-secrets
   managedSecret:

--- a/charts/mautrix-slack/values.secrets.yaml
+++ b/charts/mautrix-slack/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-slack/values.yaml
+++ b/charts/mautrix-slack/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-slack/values.yaml
+++ b/charts/mautrix-slack/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-twitter-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-twitter \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-twitter-registration
+      secretKey: appservice-registration-twitter.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-twitter/README.md
+++ b/charts/mautrix-twitter/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer). Note: this chart currently defaults to `v0.2511.0`, which predates env config support; override `image.tag` with a `v0.2512.0`-or-newer release when using `existingSecret`.
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_twitter
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_twitter
     sslMode: require

--- a/charts/mautrix-twitter/values.external.example.yaml
+++ b/charts/mautrix-twitter/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_twitter
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_twitter
     sslMode: require

--- a/charts/mautrix-twitter/values.schema.json
+++ b/charts/mautrix-twitter/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-twitter/values.schema.json
+++ b/charts/mautrix-twitter/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-twitter/values.secrets.yaml
+++ b/charts/mautrix-twitter/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-twitter/values.secrets.yaml
+++ b/charts/mautrix-twitter/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-twitter.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-twitter-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-twitter-runtime-secrets
   managedSecret:

--- a/charts/mautrix-twitter/values.yaml
+++ b/charts/mautrix-twitter/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-twitter/values.yaml
+++ b/charts/mautrix-twitter/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer).
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_whatsapp
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_whatsapp
     sslMode: require

--- a/charts/mautrix-whatsapp/README.md
+++ b/charts/mautrix-whatsapp/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-whatsapp-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-whatsapp \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-whatsapp-registration
+      secretKey: appservice-registration-whatsapp.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-whatsapp/values.external.example.yaml
+++ b/charts/mautrix-whatsapp/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_whatsapp
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_whatsapp
     sslMode: require

--- a/charts/mautrix-whatsapp/values.schema.json
+++ b/charts/mautrix-whatsapp/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-whatsapp/values.schema.json
+++ b/charts/mautrix-whatsapp/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-whatsapp/values.secrets.yaml
+++ b/charts/mautrix-whatsapp/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-whatsapp/values.secrets.yaml
+++ b/charts/mautrix-whatsapp/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-whatsapp.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-whatsapp-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-whatsapp-runtime-secrets
   managedSecret:

--- a/charts/mautrix-whatsapp/values.yaml
+++ b/charts/mautrix-whatsapp/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-whatsapp/values.yaml
+++ b/charts/mautrix-whatsapp/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -89,6 +89,7 @@ The chart renders registration in release namespace as:
 
 Set `registration.synapseNamespace` if Synapse runs in a different namespace (for example `ess`).
 An additional registration ConfigMap copy is created only when `registration.synapseNamespace` is non-empty and different from the release namespace.
+No registration ConfigMap is rendered when `registration.existingSecret` is set; see Runtime secret generation below.
 
 For ESS, add the appservice ConfigMap in Synapse values:
 
@@ -137,7 +138,6 @@ synapse:
 
 If unset, the chart resolves these in this order:
 
-- from `registration.existingSecret` (keys `asToken`, `hsToken`) when set
 - from chart-managed Secret (default `<release>-mautrix-zulip-runtime-secrets`) when it already exists
 - auto-generated 64-hex-char values when `registration.autoGenerate=true` and `registration.managedSecret.enabled=true` (default behavior)
 
@@ -147,6 +147,35 @@ The resolved values are used for:
 - `registration.hsToken`
 
 Do not set these to `generate`; leave empty for chart-managed generation.
+
+### Registration tokens from an existing Secret (GitOps-safe)
+
+When `registration.existingSecret` is set (Secret with keys `asToken` and `hsToken`), the chart never reads the Secret at template time, so rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering). The bridge reads both tokens at runtime instead:
+
+- The StatefulSet defines `MAUTRIX_HELM_CONFIG_APPSERVICE__AS_TOKEN` and `MAUTRIX_HELM_CONFIG_APPSERVICE__HS_TOKEN` via `secretKeyRef`.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `appservice.as_token`/`hs_token` from those env vars at startup. Like the Postgres mechanism, this requires a bridge release `v0.2512.0` or newer.
+- Inline `registration.asToken`/`hsToken` are mutually exclusive with `registration.existingSecret`.
+- Rotating the tokens in the Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader).
+
+**The chart does not render the registration ConfigMap in this mode** (the tokens are not available at template time), so you must provide the registration file to the homeserver from the same secret source. The easiest way to get the exact file content is to render it once with placeholder tokens:
+
+```bash
+helm template <release> charts/mautrix-zulip \
+  --set homeserver.domain=<domain> \
+  --set registration.asToken=REPLACE_AS_TOKEN \
+  --set registration.hsToken=REPLACE_HS_TOKEN \
+  --set registration.autoGenerate=false \
+  -s templates/registration-configmap.yaml
+```
+
+Store that file (with the real tokens) next to the tokens themselves — for example in Vault, delivered by Vault Secrets Operator as a Secret in the Synapse namespace via a [destination transformation template](https://developer.hashicorp.com/vault/docs/platform/k8s/vso/secret-transformation). ESS accepts Secret references for appservices:
+
+```yaml
+synapse:
+  appservices:
+    - secret: mautrix-zulip-registration
+      secretKey: appservice-registration-zulip.yaml
+```
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
 The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).

--- a/charts/mautrix-zulip/README.md
+++ b/charts/mautrix-zulip/README.md
@@ -149,6 +149,7 @@ The resolved values are used for:
 Do not set these to `generate`; leave empty for chart-managed generation.
 
 For deterministic GitOps rendering, set `registration.autoGenerate=false` and provide secrets directly or via a pre-created `registration.existingSecret`.
+The Postgres password from `database.postgres.password.existingSecret` is GitOps-safe by design: it is resolved at runtime, never at template time (see the Postgres section below).
 
 ## Bridge config model
 
@@ -212,9 +213,22 @@ logging:
 
 Bundled Postgres is enabled by default.
 
-If `database.postgres.password.value` is empty, the chart resolves it from `database.postgres.password.existingSecret` when set, otherwise from the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
+If `database.postgres.password.value` is empty and `database.postgres.password.existingSecret` is unset, the chart reuses the chart-managed Postgres Secret when present, otherwise it generates a 64-hex-char password for bundled Postgres on first install.
 
 `database.postgres.password.value` and `database.postgres.password.existingSecret` are mutually exclusive. The existing Secret is used for both bundled and external Postgres when set. Switching between password sources is allowed, and it is the operator's responsibility to ensure the selected password matches the database.
+
+When `database.postgres.password.existingSecret` is set, the chart never reads the Secret at template time. Rendering works fully offline (plain `helm template`, ArgoCD/Flux repo-side rendering) and the password is injected at runtime instead:
+
+- The bridge StatefulSet reads the password into the `MAUTRIX_HELM_DATABASE_PASSWORD` env var via `secretKeyRef` (`existingSecret`/`existingSecretKey`).
+- Kubernetes expands it into the `MAUTRIX_HELM_CONFIG_DATABASE__URI` env var holding the full connection URI.
+- The chart sets `env_config_prefix: MAUTRIX_HELM_CONFIG_` in the bridge config, so the bridge overrides `database.uri` from that env var at startup. The rendered config file itself only contains a non-secret placeholder URI.
+
+Requirements and caveats for `existingSecret`:
+
+- Requires bridge env config support from mautrix-go v0.26.1+ (bridge releases `v0.2512.0` and newer). Note: this chart currently defaults to `v0.2511.0`, which predates env config support; override `image.tag` with a `v0.2512.0`-or-newer release when using `existingSecret`.
+- The password is inserted into the URI without URL-encoding at runtime; it must not contain URI-reserved characters (`@`, `/`, `:`, `?`, `#`, `%`, spaces). Typical generated alphanumeric passwords (Vault, CloudNativePG, ...) are fine.
+- Rotating the password in the referenced Secret does not restart the bridge; pair with a reload mechanism such as [stakater/Reloader](https://github.com/stakater/Reloader) or roll the StatefulSet manually after rotation.
+- `values.config.baseExtra` cannot set `env_config_prefix` while `existingSecret` is set; the chart manages it.
 
 Disable bundled Postgres and use external DB:
 
@@ -229,8 +243,8 @@ database:
     user: mautrix_zulip
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or use an external Secret instead of `value` (see above):
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_zulip
     sslMode: require

--- a/charts/mautrix-zulip/values.external.example.yaml
+++ b/charts/mautrix-zulip/values.external.example.yaml
@@ -15,8 +15,11 @@ database:
     user: mautrix_zulip
     password:
       value: replace_me
-      # Remove `value` and replace with the below to use an external secret
-			# existingSecret: my-postgres-password
+      # Or source the password from a pre-created Secret instead of `value`.
+      # GitOps-friendly: the Secret is only referenced at runtime via
+      # secretKeyRef and never read at template time, so offline rendering
+      # (plain `helm template`, ArgoCD/Flux) works. See README "Postgres".
+      # existingSecret: my-postgres-password
       # existingSecretKey: password
     database: mautrix_zulip
     sslMode: require

--- a/charts/mautrix-zulip/values.schema.json
+++ b/charts/mautrix-zulip/values.schema.json
@@ -407,7 +407,7 @@
                 "existingSecret": {
                   "type": "string",
                   "default": "",
-                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set."
+                  "description": "Existing Secret containing the Postgres password. Mutually exclusive with value. Used for both external and bundled Postgres when set. Referenced at runtime via secretKeyRef and never read at template time (GitOps-safe). Requires a bridge release >= v0.2512.0 and a URI-safe password (no `@ / : ? # %` or spaces)."
                 },
                 "existingSecretKey": {
                   "type": "string",

--- a/charts/mautrix-zulip/values.schema.json
+++ b/charts/mautrix-zulip/values.schema.json
@@ -208,7 +208,7 @@
         "existingSecret": {
           "type": "string",
           "default": "",
-          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created."
+          "description": "Existing Secret name with keys asToken/hsToken. When set, chart-managed runtime Secret is not created, the tokens are referenced at runtime via secretKeyRef (never read at template time, GitOps-safe; requires a bridge release >= v0.2512.0), the registration ConfigMap is not rendered, and inline asToken/hsToken must be empty."
         },
         "managedSecret": {
           "type": "object",

--- a/charts/mautrix-zulip/values.secrets.yaml
+++ b/charts/mautrix-zulip/values.secrets.yaml
@@ -3,7 +3,8 @@
 #   / `  /
 #  <<   |    External Secret example for mautrix-zulip.
 #  /    |    Provide runtime secrets via a pre-created Secret.
-#  /    |    Note: template/lint output may show missing-secret info until that Secret exists.
+#  /    |    GitOps-safe: the Secret is only referenced at runtime (secretKeyRef),
+#  /    |    so offline rendering works; the Secret must exist before the pod starts.
 #
 
 homeserver:
@@ -13,6 +14,8 @@ homeserver:
 # kubectl -n <namespace> create secret generic mautrix-zulip-runtime-secrets \
 #   --from-literal=asToken="$(openssl rand -hex 32)" \
 #   --from-literal=hsToken="$(openssl rand -hex 32)"
+# Note: with existingSecret the chart renders no registration ConfigMap;
+# provide the registration file to the homeserver from the same source (see README).
 registration:
   existingSecret: mautrix-zulip-runtime-secrets
   managedSecret:

--- a/charts/mautrix-zulip/values.secrets.yaml
+++ b/charts/mautrix-zulip/values.secrets.yaml
@@ -28,6 +28,9 @@ registration:
 #     autoGenerate: false
 
 # Optional: source the Postgres password from an external Secret.
+# The Secret is referenced at runtime via secretKeyRef and never read at
+# template time, so offline/GitOps rendering works. The password must be
+# URI-safe (no `@ / : ? # %` or spaces); see README "Postgres".
 # database:
 #   postgres:
 #     password:

--- a/charts/mautrix-zulip/values.yaml
+++ b/charts/mautrix-zulip/values.yaml
@@ -130,6 +130,8 @@ database:
       # If empty and postgres.enabled=true, reused from the chart-managed Secret when present; otherwise auto-generated.
       value: ""
       # Existing Secret containing the Postgres password. Mutually exclusive with password.value.
+      # Referenced at runtime via secretKeyRef and never read at template time,
+      # so rendering stays GitOps/ArgoCD-safe. See README "Postgres" for requirements.
       existingSecret: ""
       # Key in existingSecret containing the Postgres password.
       existingSecretKey: password

--- a/charts/mautrix-zulip/values.yaml
+++ b/charts/mautrix-zulip/values.yaml
@@ -54,7 +54,11 @@ registration:
   asToken: ""
   hsToken: ""
   # Existing Secret containing keys `asToken` and `hsToken`.
-  # When set, no chart-managed runtime Secret is created.
+  # When set, no chart-managed runtime Secret is created. The tokens are
+  # referenced at runtime via secretKeyRef and never read at template time
+  # (GitOps/ArgoCD-safe), and the registration ConfigMap is not rendered;
+  # provide the registration file to the homeserver yourself (see README).
+  # Mutually exclusive with registration.asToken/hsToken.
   existingSecret: ""
   managedSecret:
     # Create a chart-managed runtime Secret when existingSecret is not set.


### PR DESCRIPTION
## What

- Drops the `lookup`-based resolution of `database.postgres.password.existingSecret` in `mautrix-go-base`; the password is now injected at runtime instead of template time.
- Docs/schema/example updates across the 10 go-base charts, plus a fix for tab-indented comment lines in `values.external.example.yaml` that made the file unparseable as YAML.

## Why

Helm's `lookup` returns nil under plain `helm template` and in ArgoCD's repo-server (argoproj/argo-cd#5202), so rendering failed with "must contain key ... in namespace ..." even when the Secret exists in the cluster - defeating the feature for its main GitOps audience.

## How it works

- `databaseConnectionString` renders the URI with a literal `$(MAUTRIX_HELM_DATABASE_PASSWORD)` placeholder instead of the password.
- The bridge StatefulSet defines `MAUTRIX_HELM_DATABASE_PASSWORD` via `secretKeyRef` (`existingSecret`/`existingSecretKey`) and `MAUTRIX_HELM_CONFIG_DATABASE__URI` with that URI; the kubelet expands the `$(VAR)` reference at container start.
- The merged bridge config gains `env_config_prefix: MAUTRIX_HELM_CONFIG_`, so the bridge overrides `database.uri` from the env var at startup (native mxmain feature, mautrix-go >= v0.26.1 / bridge releases >= v0.2512.0).
- `databasePostgresPasswordChecksum` hashes only the Secret name+key in this mode; rotating the Secret value needs a reloader (documented).
- `password.value` and bundled Postgres without `existingSecret` are unchanged.

## Reviewer notes

- mautrix-bluesky and mautrix-zulip have no upstream release >= v0.2512.0 yet; mautrix-twitter and mautrix-gvoice do, but the charts pin older appVersions. Their READMEs note to override `image.tag` when using `existingSecret`.
- mautrix-telegram, mautrix-googlechat, and matrix-appservice-irc carry their own copies of the lookup pattern and are not covered here (not mxmain-based); they need a separate approach.
- Verified: offline `helm template` (no kube context) with `existingSecret` set for all 10 charts; `helm lint` and all example values files pass; the rendered StatefulSet references the Secret via `secretKeyRef` and no password appears in the manifests; mutual-exclusivity and `env_config_prefix` conflict errors fire as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
