### PR TITLE
Relax `additionalProperties` to better support umbrella helm charts

### DIFF
--- a/charts/matrix-appservice-irc/Chart.yaml
+++ b/charts/matrix-appservice-irc/Chart.yaml
@@ -5,5 +5,5 @@ home: https://matrix-org.github.io/matrix-appservice-irc/latest/
 sources:
   - https://github.com/matrix-org/matrix-appservice-irc
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "release-4.0.0"

--- a/charts/matrix-appservice-irc/values.schema.json
+++ b/charts/matrix-appservice-irc/values.schema.json
@@ -3,7 +3,7 @@
   "title": "matrix-appservice-irc chart values",
   "description": "Configuration values for deploying matrix-appservice-irc with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "host"
   ],

--- a/charts/mautrix-bluesky/Chart.yaml
+++ b/charts/mautrix-bluesky/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/bluesky/
 sources:
   - https://github.com/mautrix/bluesky
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2510.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-bluesky/values.schema.json
+++ b/charts/mautrix-bluesky/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-bluesky chart values",
   "description": "Configuration values for deploying mautrix-bluesky with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-gmessages/Chart.yaml
+++ b/charts/mautrix-gmessages/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/gmessages/
 sources:
   - https://github.com/mautrix/gmessages
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-gmessages/values.schema.json
+++ b/charts/mautrix-gmessages/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-gmessages chart values",
   "description": "Configuration values for deploying mautrix-gmessages with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-go-base/Chart.yaml
+++ b/charts/mautrix-go-base/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/mautrix
   - https://github.com/cyclikal94/matrix-helm-charts
 type: library
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.0.0"

--- a/charts/mautrix-googlechat/Chart.yaml
+++ b/charts/mautrix-googlechat/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/googlechat/
 sources:
   - https://github.com/mautrix/googlechat
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.5.2"

--- a/charts/mautrix-googlechat/values.schema.json
+++ b/charts/mautrix-googlechat/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-googlechat chart values",
   "description": "Configuration values for deploying mautrix-googlechat with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-gvoice/Chart.yaml
+++ b/charts/mautrix-gvoice/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/gvoice/
 sources:
   - https://github.com/mautrix/gvoice
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-gvoice/values.schema.json
+++ b/charts/mautrix-gvoice/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-gvoice chart values",
   "description": "Configuration values for deploying mautrix-gvoice with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-linkedin/Chart.yaml
+++ b/charts/mautrix-linkedin/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/linkedin/
 sources:
   - https://github.com/mautrix/linkedin
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-linkedin/values.schema.json
+++ b/charts/mautrix-linkedin/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-linkedin chart values",
   "description": "Configuration values for deploying mautrix-linkedin with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-meta/Chart.yaml
+++ b/charts/mautrix-meta/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/meta/
 sources:
   - https://github.com/mautrix/meta
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-meta/values.schema.json
+++ b/charts/mautrix-meta/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-meta chart values",
   "description": "Configuration values for deploying mautrix-meta with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-signal/Chart.yaml
+++ b/charts/mautrix-signal/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/signal/
 sources:
   - https://github.com/mautrix/signal
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.2"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-signal/values.schema.json
+++ b/charts/mautrix-signal/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-signal chart values",
   "description": "Configuration values for deploying mautrix-signal with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-slack/Chart.yaml
+++ b/charts/mautrix-slack/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/slack/
 sources:
   - https://github.com/mautrix/slack
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-slack/values.schema.json
+++ b/charts/mautrix-slack/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-slack chart values",
   "description": "Configuration values for deploying mautrix-slack with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-telegram/Chart.yaml
+++ b/charts/mautrix-telegram/Chart.yaml
@@ -5,5 +5,5 @@ home: https://docs.mau.fi/bridges/python/telegram/
 sources:
   - https://github.com/mautrix/telegram
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.15.3"

--- a/charts/mautrix-telegram/values.schema.json
+++ b/charts/mautrix-telegram/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-telegram chart values",
   "description": "Configuration values for deploying mautrix-telegram with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver",
     "telegram"

--- a/charts/mautrix-twitter/Chart.yaml
+++ b/charts/mautrix-twitter/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/twitter/
 sources:
   - https://github.com/mautrix/twitter
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-twitter/values.schema.json
+++ b/charts/mautrix-twitter/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-twitter chart values",
   "description": "Configuration values for deploying mautrix-twitter with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-whatsapp/Chart.yaml
+++ b/charts/mautrix-whatsapp/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/whatsapp/
 sources:
   - https://github.com/mautrix/whatsapp
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2602.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-whatsapp/values.schema.json
+++ b/charts/mautrix-whatsapp/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-whatsapp chart values",
   "description": "Configuration values for deploying mautrix-whatsapp with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/mautrix-zulip/Chart.yaml
+++ b/charts/mautrix-zulip/Chart.yaml
@@ -5,7 +5,7 @@ home: https://docs.mau.fi/bridges/go/zulip/
 sources:
   - https://github.com/mautrix/zulip
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v0.2511.0"
 dependencies:
   - name: mautrix-go-base

--- a/charts/mautrix-zulip/values.schema.json
+++ b/charts/mautrix-zulip/values.schema.json
@@ -3,7 +3,7 @@
   "title": "mautrix-zulip chart values",
   "description": "Configuration values for deploying mautrix-zulip with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "homeserver"
   ],

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -6,5 +6,5 @@ home: https://ntfy.sh
 sources:
   - https://github.com/binwiederhier/ntfy
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v2.17.0"

--- a/charts/ntfy/values.schema.json
+++ b/charts/ntfy/values.schema.json
@@ -3,7 +3,7 @@
   "title": "ntfy chart values",
   "description": "Configuration values for deploying ntfy with this Helm chart.",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "host"
   ],


### PR DESCRIPTION
This resolves #42 so charts using these charts as dependencies can supply custom additional properties without errors.

Note that top-level typos in chart values will no longer be rejected by schema validation however.