### PR TITLE
Validate PRs increment helm chart version

### DIFF
--- a/.github/scripts/validate_chart_versions.js
+++ b/.github/scripts/validate_chart_versions.js
@@ -1,0 +1,270 @@
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+
+function git(args, options = {}) {
+  return execFileSync("git", ["-c", "safe.directory=*", ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", options.allowFailure ? "pipe" : "inherit"],
+  }).trimEnd();
+}
+
+function gitMaybe(args) {
+  try {
+    return git(args, { allowFailure: true });
+  } catch {
+    return null;
+  }
+}
+
+function readAt(ref, filePath) {
+  return gitMaybe(["show", `${ref}:${filePath}`]);
+}
+
+function parseSimpleYamlField(content, key) {
+  if (!content) {
+    return "";
+  }
+
+  const re = new RegExp(`^${key}:\\s*"?([^"\\n#]+)"?\\s*$`, "m");
+  const match = content.match(re);
+  return match ? match[1].trim() : "";
+}
+
+function parseTopLevelImageTag(content) {
+  if (!content) {
+    return "";
+  }
+
+  const lines = content.split(/\r?\n/);
+  let inImageBlock = false;
+
+  for (const line of lines) {
+    if (!inImageBlock) {
+      if (/^image:\s*$/.test(line)) {
+        inImageBlock = true;
+      }
+      continue;
+    }
+
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      continue;
+    }
+
+    if (/^\S/.test(line)) {
+      break;
+    }
+
+    const tagMatch = line.match(/^\s+tag:\s*"?([^"\s#]+)"?/);
+    if (tagMatch) {
+      return tagMatch[1].trim();
+    }
+  }
+
+  return "";
+}
+
+function parseSemver(version) {
+  const match = String(version || "").trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function classifyVersionBump(previousVersion, nextVersion) {
+  const previous = parseSemver(previousVersion);
+  const next = parseSemver(nextVersion);
+
+  if (!previous || !next) {
+    return "invalid";
+  }
+  if (next.major > previous.major) {
+    return "major";
+  }
+  if (next.major < previous.major) {
+    return "downgrade";
+  }
+  if (next.minor > previous.minor) {
+    return "minor";
+  }
+  if (next.minor < previous.minor) {
+    return "downgrade";
+  }
+  if (next.patch > previous.patch) {
+    return "patch";
+  }
+  if (next.patch < previous.patch) {
+    return "downgrade";
+  }
+  return "none";
+}
+
+function bumpMeetsRequirement(actual, required) {
+  const rank = {
+    none: 0,
+    patch: 1,
+    minor: 2,
+    major: 3,
+  };
+  return (rank[actual] || 0) >= rank[required];
+}
+
+function minimumVersionForBump(previousVersion, requiredBump) {
+  const previous = parseSemver(previousVersion);
+  if (!previous) {
+    return "";
+  }
+
+  if (requiredBump === "major") {
+    return `${previous.major + 1}.0.0`;
+  }
+  if (requiredBump === "minor") {
+    return `${previous.major}.${previous.minor + 1}.0`;
+  }
+  return `${previous.major}.${previous.minor}.${previous.patch + 1}`;
+}
+
+function getFallbackBaseSha(headSha) {
+  return gitMaybe(["rev-parse", `${headSha}^`]);
+}
+
+const headSha = process.env.HEAD_SHA || "HEAD";
+const baseSha = process.env.BASE_SHA || getFallbackBaseSha(headSha);
+const diffStyle = process.env.DIFF_STYLE || "range";
+
+if (!baseSha) {
+  console.log("No base SHA available; skipping chart version validation.");
+  process.exit(0);
+}
+
+const diffArgs = ["diff", "--name-only"];
+if (diffStyle === "merge-base") {
+  diffArgs.push(`${baseSha}...${headSha}`);
+} else {
+  diffArgs.push(baseSha, headSha);
+}
+const diffOutput = git(diffArgs);
+const changedFiles = diffOutput.split(/\r?\n/).filter(Boolean);
+const changedCharts = new Map();
+
+for (const filePath of changedFiles) {
+  const match = filePath.match(/^charts\/([^/]+)\//);
+  if (!match) {
+    continue;
+  }
+
+  const chart = match[1];
+  const files = changedCharts.get(chart) || [];
+  files.push(filePath);
+  changedCharts.set(chart, files);
+}
+
+if (changedCharts.size === 0) {
+  console.log("No chart changes detected.");
+  process.exit(0);
+}
+
+const failures = [];
+const results = [];
+
+for (const [chart, files] of Array.from(changedCharts.entries()).sort()) {
+  const chartPath = `charts/${chart}/Chart.yaml`;
+  const valuesPath = `charts/${chart}/values.yaml`;
+  const previousChartYaml = readAt(baseSha, chartPath);
+  const nextChartYaml = readAt(headSha, chartPath);
+
+  if (!previousChartYaml || !nextChartYaml) {
+    console.log(`Skipping ${chart}: chart was added or removed.`);
+    continue;
+  }
+
+  const previousVersion = parseSimpleYamlField(previousChartYaml, "version");
+  const nextVersion = parseSimpleYamlField(nextChartYaml, "version");
+  const previousAppVersion = parseSimpleYamlField(previousChartYaml, "appVersion");
+  const nextAppVersion = parseSimpleYamlField(nextChartYaml, "appVersion");
+  const previousImageTag = parseTopLevelImageTag(readAt(baseSha, valuesPath));
+  const nextImageTag = parseTopLevelImageTag(readAt(headSha, valuesPath));
+  const appVersionChanged = previousAppVersion !== nextAppVersion;
+  const imageTagChanged = previousImageTag !== nextImageTag;
+  const requiredBump = appVersionChanged || imageTagChanged ? "minor" : "patch";
+  const actualBump = classifyVersionBump(previousVersion, nextVersion);
+  const suggestedVersion = minimumVersionForBump(previousVersion, requiredBump);
+  const chartFailures = [];
+
+  console.log(`${chart}: changed files=${files.length}, chart version ${previousVersion || "n/a"} -> ${nextVersion || "n/a"}, appVersion ${previousAppVersion || "n/a"} -> ${nextAppVersion || "n/a"}, image.tag ${previousImageTag || "n/a"} -> ${nextImageTag || "n/a"}`);
+
+  if (actualBump === "invalid") {
+    chartFailures.push(`Chart.yaml version must be simple semver x.y.z (${previousVersion || "missing"} -> ${nextVersion || "missing"}).`);
+    failures.push(`${chart}: ${chartFailures[chartFailures.length - 1]}`);
+    results.push({
+      chart,
+      previousVersion,
+      nextVersion,
+      previousAppVersion,
+      nextAppVersion,
+      previousImageTag,
+      nextImageTag,
+      requiredBump,
+      actualBump,
+      suggestedVersion,
+      failures: chartFailures,
+    });
+    continue;
+  }
+
+  if (actualBump === "downgrade" || actualBump === "none") {
+    chartFailures.push(`Chart files changed, so Chart.yaml version must increase at least a ${requiredBump} version (${previousVersion} -> ${suggestedVersion || "a higher version"}).`);
+  } else if (!bumpMeetsRequirement(actualBump, requiredBump)) {
+    chartFailures.push(`${appVersionChanged || imageTagChanged ? "appVersion or image.tag changed" : "Chart files changed"}, so Chart.yaml version must increase by at least ${requiredBump} (${previousVersion} -> ${suggestedVersion || "a higher version"}; submitted ${nextVersion}, which was ${actualBump}).`);
+  }
+
+  if (imageTagChanged && !appVersionChanged) {
+    chartFailures.push(`values.yaml image.tag changed (${previousImageTag || "n/a"} -> ${nextImageTag || "n/a"}), so Chart.yaml appVersion must also change.`);
+  }
+
+  if (imageTagChanged && nextAppVersion && nextImageTag && nextAppVersion !== nextImageTag) {
+    chartFailures.push(`values.yaml image.tag changed to ${nextImageTag}, but Chart.yaml appVersion is ${nextAppVersion}. Keep appVersion aligned with the primary app image tag.`);
+  }
+
+  for (const failure of chartFailures) {
+    failures.push(`${chart}: ${failure}`);
+  }
+
+  results.push({
+    chart,
+    previousVersion,
+    nextVersion,
+    previousAppVersion,
+    nextAppVersion,
+    previousImageTag,
+    nextImageTag,
+    requiredBump,
+    actualBump,
+    suggestedVersion,
+    failures: chartFailures,
+  });
+}
+
+if (process.env.REPORT_PATH) {
+  fs.writeFileSync(process.env.REPORT_PATH, JSON.stringify({
+    ok: failures.length === 0,
+    baseSha,
+    headSha,
+    diffStyle,
+    results,
+    failures,
+  }, null, 2));
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`::error::${failure}`);
+  }
+  console.error(["Chart version validation failed:", ...failures.map((failure) => `- ${failure}`)].join("\n"));
+  process.exit(1);
+}

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "charts/**"
+      - ".github/scripts/validate_chart_versions.js"
       - ".github/workflows/release-charts.yaml"
   workflow_dispatch:
 
@@ -19,7 +20,23 @@ permissions:
   packages: write
 
 jobs:
+  validate-chart-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate changed chart versions
+        run: node .github/scripts/validate_chart_versions.js
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          DIFF_STYLE: range
+
   release:
+    needs: validate-chart-versions
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/validate-chart-versions.yaml
+++ b/.github/workflows/validate-chart-versions.yaml
@@ -10,6 +10,12 @@ on:
       - "charts/**"
       - ".github/scripts/validate_chart_versions.js"
       - ".github/workflows/validate-chart-versions.yaml"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to validate"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,7 +23,57 @@ permissions:
   pull-requests: read
 
 jobs:
+  resolve-context:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      base_sha: ${{ steps.resolve.outputs.base_sha }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+    steps:
+      - name: Resolve PR context
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr;
+
+            if (context.eventName === "pull_request") {
+              pr = context.payload.pull_request;
+            } else {
+              const prNumberRaw = context.payload.inputs?.pr_number;
+              const prNumber = Number(prNumberRaw);
+              if (!Number.isInteger(prNumber) || prNumber <= 0) {
+                core.setFailed(`Invalid pr_number input: ${prNumberRaw}`);
+                return;
+              }
+
+              pr = (await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              })).data;
+            }
+
+            if (!pr) {
+              core.setFailed("Unable to resolve PR context.");
+              return;
+            }
+
+            const prNumber = String(pr.number);
+            const baseSha = pr.base?.sha || "";
+            const headSha = pr.head?.sha || "";
+
+            if (!baseSha || !headSha) {
+              core.setFailed(`PR #${prNumber} is missing base/head SHA information.`);
+              return;
+            }
+
+            core.setOutput("pr_number", prNumber);
+            core.setOutput("base_sha", baseSha);
+            core.setOutput("head_sha", headSha);
+
   validate:
+    needs: resolve-context
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,8 +86,8 @@ jobs:
         continue-on-error: true
         run: node .github/scripts/validate_chart_versions.js
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ needs.resolve-context.outputs.base_sha }}
+          HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
           DIFF_STYLE: merge-base
           REPORT_PATH: chart-version-validation.json
 
@@ -47,7 +103,7 @@ jobs:
 
             const marker = "<!-- chart-version-validation -->";
             const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
+            const issue_number = Number("${{ needs.resolve-context.outputs.pr_number }}");
             const reportPath = process.env.REPORT_PATH;
             const report = fs.existsSync(reportPath)
               ? JSON.parse(fs.readFileSync(reportPath, "utf8"))

--- a/.github/workflows/validate-chart-versions.yaml
+++ b/.github/workflows/validate-chart-versions.yaml
@@ -1,0 +1,119 @@
+name: Validate Chart Versions
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "charts/**"
+      - ".github/scripts/validate_chart_versions.js"
+      - ".github/workflows/validate-chart-versions.yaml"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate changed chart versions
+        id: validate
+        continue-on-error: true
+        run: node .github/scripts/validate_chart_versions.js
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DIFF_STYLE: merge-base
+          REPORT_PATH: chart-version-validation.json
+
+      - name: Update validation comment
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: chart-version-validation.json
+        with:
+          script: |
+            const fs = require("node:fs");
+
+            const marker = "<!-- chart-version-validation -->";
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const reportPath = process.env.REPORT_PATH;
+            const report = fs.existsSync(reportPath)
+              ? JSON.parse(fs.readFileSync(reportPath, "utf8"))
+              : { ok: true, failures: [], results: [] };
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (report.ok) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            const failedCharts = (report.results || []).filter((result) =>
+              (result.failures || []).length > 0
+            );
+            const lines = [
+              marker,
+              "Chart version validation failed.",
+              "",
+              "How to fix:",
+              "- For chart-only changes, bump `charts/<chart>/Chart.yaml` `version` by at least a patch version, for example `1.0.0` -> `1.0.1`.",
+              "- If `Chart.yaml` `appVersion` changes, bump the chart `version` by at least a minor version, for example `1.0.0` -> `1.1.0`.",
+              "- If top-level `values.yaml` `image.tag` changes, update `Chart.yaml` `appVersion` to the same tag and use at least a minor chart version bump.",
+              "",
+              "| Chart | Chart version | appVersion | image.tag | Required bump | Issue |",
+              "| --- | --- | --- | --- | --- | --- |",
+            ];
+
+            for (const result of failedCharts) {
+              const issue = (result.failures || []).join("<br>");
+              lines.push(
+                `| \`${result.chart}\` | \`${result.previousVersion || "n/a"}\` -> \`${result.nextVersion || "n/a"}\` | \`${result.previousAppVersion || "n/a"}\` -> \`${result.nextAppVersion || "n/a"}\` | \`${result.previousImageTag || "n/a"}\` -> \`${result.nextImageTag || "n/a"}\` | \`${result.requiredBump}\` | ${issue} |`
+              );
+            }
+
+            const body = lines.join("\n");
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Fail workflow on validation errors
+        if: steps.validate.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
This adds a shared validator that checks changed charts bump `Chart.yaml` versions, for chart only changes, only a patch level bump is required.

When the top-level `values.yaml` `image.tag` changes, the validator expects:
- `Chart.yaml` `appVersion` must change.
- `Chart.yaml` `appVersion` must match the new top-level `image.tag`.
- `Chart.yaml` `version` must receive at least a minor bump.

There was some protection but this should add to it, and notify PRs of the required changes.